### PR TITLE
OpenROAD gui fix

### DIFF
--- a/scripts/asic/run_layout_viewer.mk
+++ b/scripts/asic/run_layout_viewer.mk
@@ -1,5 +1,7 @@
 include Makefile
 
+DOCKER_OPTIONS +=--privileged
+
 ifeq ($(LAYOUT_VIEWER),)
   LAYOUT_VIEWER_OPTION =
 else ifeq ($(LAYOUT_VIEWER),openroad)


### PR DESCRIPTION
fix for run  08_visualize_asic_synthesis_results_1.bash and 09_visualize_asic_synthesis_results_2.bash execution  
in Ubuntu 20.0
More in:
https://github.com/The-OpenROAD-Project/OpenLane/issues/1149