### PR TITLE
Altera boards: mic, tm1638 pins optimization

### DIFF
--- a/boards/c5gx/board_specific_top.sv
+++ b/boards/c5gx/board_specific_top.sv
@@ -7,7 +7,7 @@ module board_specific_top
               w_sw    = 10,
               w_led   = 18,
               w_digit = 4,
-              w_gpio  = 22
+              w_gpio  = 22          // GPIO[5:0] reserved for mic
 )
 (
     input                 CLOCK_50_B8A,
@@ -15,10 +15,10 @@ module board_specific_top
 
     input  [w_key  - 1:0] KEY,
     input  [w_sw   - 1:0] SW,
-    output [         9:0] LEDR, // The last 4 LEDR are used like a 7SEG dp
+    output [         9:0] LEDR,     // The last 4 LEDR are used like a 7SEG dp
     output [         7:0] LEDG,
 
-    output logic [   6:0] HEX0, // HEX[7] aka dp doesn't connected to FPGA at "Cyclone V GX Starter Kit"
+    output logic [   6:0] HEX0,     // HEX[7] aka dp doesn't connected to FPGA at "Cyclone V GX Starter Kit"
     output logic [   6:0] HEX1,
     output logic [   6:0] HEX2,
     output logic [   6:0] HEX3,
@@ -28,7 +28,7 @@ module board_specific_top
     inout  [w_gpio - 1:0] GPIO
 );
 
-    localparam w_top_sw = w_sw - 1;                // One sw is used as a reset
+    localparam w_top_sw = w_sw - 1; // One sw is used as a reset
 
     wire                  clk     = CLOCK_50_B8A;
     wire                  rst     = ~ CPU_RESET_n;
@@ -55,9 +55,9 @@ module board_specific_top
         .clk_mhz ( clk_mhz         ),
         .w_key   ( w_key           ),
         .w_sw    ( w_top_sw        ),
-        .w_led   ( w_led - w_digit ),                          // The last 4 LEDR are used like a 7SEG dp
+        .w_led   ( w_led - w_digit ), // The last 4 LEDR are used like a 7SEG dp
         .w_digit ( w_digit         ),
-        .w_gpio  ( w_gpio          )
+        .w_gpio  ( w_gpio          )  // GPIO[5:0] reserved for mic
     )
     i_top
     (
@@ -177,14 +177,14 @@ module board_specific_top
     (
         .clk   ( clk      ),
         .rst   ( rst      ),
-        .lr    ( GPIO [5] ), // JP9 pin 6
-        .ws    ( GPIO [3] ), // JP9 pin 4
-        .sck   ( GPIO [1] ), // JP9 pin 2
-        .sd    ( GPIO [0] ), // JP9 pin 1
+        .lr    ( GPIO [0] ), // JP1 pin 1
+        .ws    ( GPIO [2] ), // JP1 pin 3
+        .sck   ( GPIO [4] ), // JP1 pin 5
+        .sd    ( GPIO [5] ), // JP1 pin 6
         .value ( mic      )
     );
 
-    assign GPIO [4] = 1'b0;  // GND - JP9 pin 5
-    assign GPIO [2] = 1'b1;  // VCC - JP9 pin 3
+    assign GPIO [1] = 1'b0;  // GND - JP1 pin 2
+    assign GPIO [3] = 1'b1;  // VCC - JP1 pin 4
 
 endmodule

--- a/boards/de0/board_specific_top.sv
+++ b/boards/de0/board_specific_top.sv
@@ -7,7 +7,7 @@ module board_specific_top
               w_sw    = 10,          // One onboard SW is used as a reset
               w_led   = 10,
               w_digit = 4,
-              w_gpio  = 64
+              w_gpio  = 64           // GPIO_0[7:2] reserved for mic
 )
 (
     input                CLOCK_50,
@@ -61,7 +61,7 @@ module board_specific_top
         .w_sw    ( w_top_sw ),
         .w_led   ( w_led    ),
         .w_digit ( w_digit  ),
-        .w_gpio  ( w_gpio   )
+        .w_gpio  ( w_gpio   )        // GPIO_0[7:2] reserved for mic
     )
     i_top
     (
@@ -149,14 +149,14 @@ module board_specific_top
     (
         .clk   (   clk         ),
         .rst   (   rst         ),
-        .lr    (   GPIO0_D [7] ), // JP4 pin 10
-        .ws    (   GPIO0_D [5] ), // JP4 pin 8
-        .sck   (   GPIO0_D [3] ), // JP4 pin 6
-        .sd    (   GPIO0_D [2] ), // JP4 pin 5
+        .lr    (   GPIO0_D [2] ), // JP4 pin 5
+        .ws    (   GPIO0_D [4] ), // JP4 pin 7
+        .sck   (   GPIO0_D [6] ), // JP4 pin 9
+        .sd    (   GPIO0_D [7] ), // JP4 pin 10
         .value (   mic         )
     );
 
-    assign GPIO0_D [6] = 1'b0;    // GND - JP4 pin 9
-    assign GPIO0_D [4] = 1'b1;    // VCC - JP4 pin 7
+    assign GPIO0_D [3] = 1'b0;    // GND - JP4 pin 6
+    assign GPIO0_D [5] = 1'b1;    // VCC - JP4 pin 8
 
 endmodule

--- a/boards/de0_cv/board_specific_top.sv
+++ b/boards/de0_cv/board_specific_top.sv
@@ -7,7 +7,7 @@ module board_specific_top
               w_sw    = 10,
               w_led   = 10,
               w_digit = 6,
-              w_gpio  = 72
+              w_gpio  = 72     // GPIO_0[5:0] reserved for mic
 )
 (
     input                CLOCK_50,
@@ -57,9 +57,9 @@ module board_specific_top
         .clk_mhz ( clk_mhz         ),
         .w_key   ( w_key           ),
         .w_sw    ( w_sw            ),
-        .w_led   ( w_led - w_digit ),              // The last 6 LEDR are used like a 7SEG dp
+        .w_led   ( w_led - w_digit ),            // The last 6 LEDR are used like a 7SEG dp
         .w_digit ( w_digit         ),
-        .w_gpio  ( w_gpio          )
+        .w_gpio  ( w_gpio          )             // GPIO_0[5:0] reserved for mic
     )
     i_top
     (
@@ -168,14 +168,14 @@ module board_specific_top
     (
         .clk   ( clk        ),
         .rst   ( rst        ),
-        .lr    ( GPIO_0 [5] ), // JP1 pin 6
-        .ws    ( GPIO_0 [3] ), // JP1 pin 4
-        .sck   ( GPIO_0 [1] ), // JP1 pin 2
-        .sd    ( GPIO_0 [0] ), // JP1 pin 1
-        .value ( mic        )
+        .lr    ( GPIO_0 [0] ), // JP1 pin 1
+        .ws    ( GPIO_0 [2] ), // JP1 pin 3
+        .sck   ( GPIO_0 [4] ), // JP1 pin 5
+        .sd    ( GPIO_0 [5] ), // JP1 pin 6
+        .value ( mic      )
     );
 
-    assign GPIO_0 [4] = 1'b0;  // GND - JP1 pin 5
-    assign GPIO_0 [2] = 1'b1;  // VCC - JP1 pin 3
+    assign GPIO_0 [1] = 1'b0;  // GND - JP1 pin 2
+    assign GPIO_0 [3] = 1'b1;  // VCC - JP1 pin 4
 
 endmodule

--- a/boards/de0_nano/board_specific_top.sv
+++ b/boards/de0_nano/board_specific_top.sv
@@ -115,7 +115,7 @@ module board_specific_top
         .w_sw    ( w_top_sw    ),
         .w_led   ( w_top_led   ),
         .w_digit ( w_top_digit ),
-        .w_gpio  ( w_gpio - 3  )      // GPIO_0 [31], [32], [33] reserved for tm1638
+        .w_gpio  ( w_gpio      )      // GPIO_0 [31], [33], [35] reserved for tm1638, GPIO_0[5:0] for mic
     )
     i_top
     (
@@ -196,17 +196,17 @@ module board_specific_top
     )
     i_ledkey
     (
-        .clk        ( clk           ), // 50 MHz
+        .clk        ( clk           ),
         .rst        ( rst           ), // Don't make reset tm1638_board_controller by it's tm_key
         .static_hex ( tm_static_hex ),
         .hgfedcba   ( hgfedcba      ),
         .digit      ( tm_digit      ),
         .ledr       ( tm_led        ),
         .keys       ( tm_key        ),
+        .sio_stb    ( GPIO_0 [29]   ), // JP1 pin 36
         .sio_clk    ( GPIO_0 [31]   ), // JP1 pin 38
-        .sio_stb    ( GPIO_0 [32]   ), // JP1 pin 39
         .sio_data   ( GPIO_0 [33]   )  // JP1 pin 40
-    );
+    );                                 // JP1 pin 30 - GND, pin 29 - VCC 3.3V
 
     //------------------------------------------------------------------------
 
@@ -214,14 +214,14 @@ module board_specific_top
     (
         .clk   ( clk        ),
         .rst   ( rst        ),
-        .lr    ( GPIO_0 [5] ),  // JP1 pin 8
-        .ws    ( GPIO_0 [3] ),  // JP1 pin 6
-        .sck   ( GPIO_0 [1] ),  // JP1 pin 4
-        .sd    ( GPIO_0 [0] ),  // JP1 pin 2
+        .lr    ( GPIO_0 [2] ),  // JP1 pin 5
+        .ws    ( GPIO_0 [4] ),  // JP1 pin 7
+        .sck   ( GPIO_0 [6] ),  // JP1 pin 9
+        .sd    ( GPIO_0 [7] ),  // JP1 pin 10
         .value ( mic        )
     );
 
-    assign GPIO_0 [4] = 1'b0;   // GND - JP1 pin 7
-    assign GPIO_0 [2] = 1'b1;   // VCC - JP1 pin 5
+    assign GPIO_0 [3] = 1'b0;   // GND - JP1 pin 6
+    assign GPIO_0 [5] = 1'b1;   // VCC - JP1 pin 8
 
 endmodule

--- a/boards/de0_nano_soc/board_specific_top.sv
+++ b/boards/de0_nano_soc/board_specific_top.sv
@@ -116,7 +116,7 @@ module board_specific_top
         .w_sw    ( w_top_sw    ),
         .w_led   ( w_top_led   ),
         .w_digit ( w_top_digit ),
-        .w_gpio  ( w_gpio - 3  )        // GPIO_0 [31], [33], [35] reserved for tm1638, GPIO_0[5:0] reserved for mic
+        .w_gpio  ( w_gpio      )        // GPIO_0 [31], [33], [35] reserved for tm1638, GPIO_0[5:0] reserved for mic
     )
     i_top
     (

--- a/boards/de0_nano_soc/board_specific_top.sv
+++ b/boards/de0_nano_soc/board_specific_top.sv
@@ -11,7 +11,7 @@ module board_specific_top
               w_sw     = 4,
               w_led    = 8,
               w_digit  = 0,
-              w_gpio   = 36                   // GPIO_0 [33], [34], [35] reserved for tm1638, GPIO_0[5:0] reserved for mic
+              w_gpio   = 36                   // GPIO_0 [31], [33], [35] reserved for tm1638, GPIO_0[5:0] reserved for mic
 )
 (
     input                    FPGA_CLK1_50,
@@ -116,7 +116,7 @@ module board_specific_top
         .w_sw    ( w_top_sw    ),
         .w_led   ( w_top_led   ),
         .w_digit ( w_top_digit ),
-        .w_gpio  ( w_gpio - 3  )      // GPIO_0 [33], [34], [35] reserved for tm1638
+        .w_gpio  ( w_gpio - 3  )        // GPIO_0 [31], [33], [35] reserved for tm1638, GPIO_0[5:0] reserved for mic
     )
     i_top
     (
@@ -203,17 +203,17 @@ module board_specific_top
     )
     i_ledkey
     (
-        .clk        ( clk           ), // 50 MHz
+        .clk        ( clk           ),
         .rst        ( rst           ), // Don't make reset tm1638_board_controller by it's tm_key
         .static_hex ( tm_static_hex ),
         .hgfedcba   ( hgfedcba      ),
         .digit      ( tm_digit      ),
         .ledr       ( tm_led        ),
         .keys       ( tm_key        ),
-        .sio_clk    ( GPIO_0 [33]   ), // JP1 pin 38
-        .sio_stb    ( GPIO_0 [34]   ), // JP1 pin 39
+        .sio_clk    ( GPIO_0 [31]   ), // JP1 pin 36
+        .sio_stb    ( GPIO_0 [33]   ), // JP1 pin 38
         .sio_data   ( GPIO_0 [35]   )  // JP1 pin 40
-    );
+    );                                 // JP1 pin 30 - GND, pin 29 - VCC 3.3V
 
     //------------------------------------------------------------------------
 
@@ -221,14 +221,14 @@ module board_specific_top
     (
         .clk   ( clk        ),
         .rst   ( rst        ),
-        .lr    ( GPIO_0 [5] ),  // JP1 pin 6
-        .ws    ( GPIO_0 [3] ),  // JP1 pin 4
-        .sck   ( GPIO_0 [1] ),  // JP1 pin 2
-        .sd    ( GPIO_0 [0] ),  // JP1 pin 1
+        .lr    ( GPIO_0 [0] ),  // JP1 pin 1
+        .ws    ( GPIO_0 [2] ),  // JP1 pin 3
+        .sck   ( GPIO_0 [4] ),  // JP1 pin 5
+        .sd    ( GPIO_0 [5] ),  // JP1 pin 6
         .value ( mic        )
     );
 
-    assign GPIO_0 [4] = 1'b0;   // GND - JP1 pin 5
-    assign GPIO_0 [2] = 1'b1;   // VCC - JP1 pin 3
+    assign GPIO_0 [1] = 1'b0;   // GND - JP1 pin 2
+    assign GPIO_0 [3] = 1'b1;   // VCC - JP1 pin 4
 
 endmodule

--- a/boards/de10_lite/board_specific_top.sv
+++ b/boards/de10_lite/board_specific_top.sv
@@ -7,7 +7,7 @@ module board_specific_top
               w_sw    = 10,
               w_led   = 10,
               w_digit = 6,
-              w_gpio  = 36
+              w_gpio  = 36             // GPIO[5:0] reserved for mic
 )
 (
     input                 MAX10_CLK1_50,
@@ -58,7 +58,7 @@ module board_specific_top
         .w_sw    ( w_top_sw ),
         .w_led   ( w_led    ),
         .w_digit ( w_digit  ),
-        .w_gpio  ( w_gpio   )
+        .w_gpio  ( w_gpio   )          // GPIO[5:0] reserved for mic
     )
     i_top
     (
@@ -141,14 +141,14 @@ module board_specific_top
     (
         .clk   ( clk      ),
         .rst   ( rst      ),
-        .lr    ( GPIO [5] ), // JP1 pin 6
-        .ws    ( GPIO [3] ), // JP1 pin 4
-        .sck   ( GPIO [1] ), // JP1 pin 2
-        .sd    ( GPIO [0] ), // JP1 pin 1
+        .lr    ( GPIO [0] ), // JP1 pin 1
+        .ws    ( GPIO [2] ), // JP1 pin 3
+        .sck   ( GPIO [4] ), // JP1 pin 5
+        .sd    ( GPIO [5] ), // JP1 pin 6
         .value ( mic      )
     );
 
-    assign GPIO [4] = 1'b0;  // GND - JP1 pin 5
-    assign GPIO [2] = 1'b1;  // VCC - JP1 pin 3
+    assign GPIO [1] = 1'b0;  // GND - JP1 pin 2
+    assign GPIO [3] = 1'b1;  // VCC - JP1 pin 4
 
 endmodule

--- a/boards/de10_lite_tm1638/board_specific_top.sv
+++ b/boards/de10_lite_tm1638/board_specific_top.sv
@@ -11,7 +11,7 @@ module board_specific_top
               w_sw    = 10,
               w_led   = 10,
               w_digit = 6,
-              w_gpio  = 36                   // GPIO [33], [34], [35] reserved for tm1638, GPIO[5:0] reserved for mic
+              w_gpio  = 36                   // GPIO [31], [33], [35] reserved for tm1638, GPIO[5:0] reserved for mic
 )
 (
     input                 MAX10_CLK1_50,
@@ -126,7 +126,7 @@ module board_specific_top
         .w_sw    ( w_top_sw    ),
         .w_led   ( w_top_led   ),
         .w_digit ( w_top_digit ),
-        .w_gpio  ( w_gpio - 3  )      // GPIO_0 [33], [34], [35] reserved for tm1638
+        .w_gpio  ( w_gpio      )      // GPIO [31], [33], [35] reserved for tm1638, GPIO[5:0] reserved for mic
     )
     i_top
     (
@@ -219,20 +219,17 @@ module board_specific_top
     )
     i_ledkey
     (
-        .clk        ( clk           ), // 50 MHz
+        .clk        ( clk           ),
         .rst        ( rst           ), // Don't make reset tm1638_board_controller by it's tm_key
         .static_hex ( tm_static_hex ),
         .hgfedcba   ( hgfedcba      ),
         .digit      ( tm_digit      ),
         .ledr       ( tm_led        ),
         .keys       ( tm_key        ),
-        .sio_clk    ( GPIO [32]     ), // JP1 pin 37
-        .sio_stb    ( GPIO [30]     ), // JP1 pin 35
-        .sio_data   ( GPIO [34]     )  // JP1 pin 39
-    );
-
-    assign GPIO [28] = 1'b0;  // GND - JP1 pin 33
-    assign GPIO [26] = 1'b1;  // VCC - JP1 pin 31
+        .sio_stb    ( GPIO [31]     ), // JP1 pin 36
+        .sio_clk    ( GPIO [33]     ), // JP1 pin 38
+        .sio_data   ( GPIO [35]     )  // JP1 pin 40
+    );                                 // JP1 pin 30 - GND, pin 29 - VCC 3.3V
 
     //------------------------------------------------------------------------
 
@@ -240,16 +237,14 @@ module board_specific_top
     (
         .clk   ( clk      ),
         .rst   ( rst      ),
-        .lr    ( GPIO [9] ), // JP1 pin 10
-        .ws    ( GPIO [7] ), // JP1 pin 8
-        .sck   ( GPIO [5] ), // JP1 pin 6
-        .sd    ( GPIO [4] ), // JP1 pin 5
+        .lr    ( GPIO [0] ), // JP1 pin 1
+        .ws    ( GPIO [2] ), // JP1 pin 3
+        .sck   ( GPIO [4] ), // JP1 pin 5
+        .sd    ( GPIO [5] ), // JP1 pin 6
         .value ( mic      )
     );
 
-    assign GPIO [8] = 1'b0;  // GND - JP1 pin 9
-    assign GPIO [6] = 1'b1;  // VCC - JP1 pin 7
+    assign GPIO [1] = 1'b0;  // GND - JP1 pin 2
+    assign GPIO [3] = 1'b1;  // VCC - JP1 pin 4
 
 endmodule
-
-// TODO Review the order of tm_key

--- a/boards/de10_nano/board_specific_top.sv
+++ b/boards/de10_nano/board_specific_top.sv
@@ -11,7 +11,7 @@ module board_specific_top
               w_sw     = 4,
               w_led    = 8,
               w_digit  = 0,
-              w_gpio   = 36                   // GPIO_0 [33], [34], [35] reserved for tm1638, GPIO_0[5:0] reserved for mic
+              w_gpio   = 36                   // GPIO_0 [31], [33], [35] reserved for tm1638, GPIO_0[5:0] reserved for mic
 )
 (
     input                    FPGA_CLK1_50,
@@ -115,7 +115,7 @@ module board_specific_top
         .w_sw    ( w_top_sw    ),
         .w_led   ( w_top_led   ),
         .w_digit ( w_top_digit ),
-        .w_gpio  ( w_gpio      )      // GPIO_0 [33], [34], [35] reserved for tm1638
+        .w_gpio  ( w_gpio      )      // GPIO_0 [31], [33], [35] reserved for tm1638, GPIO_0[5:0] reserved for mic
     )
     i_top
     (
@@ -209,10 +209,10 @@ module board_specific_top
         .digit      ( tm_digit      ),
         .ledr       ( tm_led        ),
         .keys       ( tm_key        ),
-        .sio_clk    ( GPIO_0 [33]   ), // JP1 pin 38
         .sio_stb    ( GPIO_0 [31]   ), // JP1 pin 36
+        .sio_clk    ( GPIO_0 [33]   ), // JP1 pin 38
         .sio_data   ( GPIO_0 [35]   )  // JP1 pin 40
-    );
+    );                                 // JP1 pin 30 - GND, pin 29 - VCC 3.3V
 
     //------------------------------------------------------------------------
 

--- a/boards/de1_soc/board_specific_top.sv
+++ b/boards/de1_soc/board_specific_top.sv
@@ -7,7 +7,7 @@ module board_specific_top
               w_sw      = 10,
               w_led     = 10,
               w_digit   = 6,
-              w_gpio    = 72,
+              w_gpio    = 72,        // GPIO_0[5:0] reserved for mic
               vga_clock = 25         // Pixel clock of VGA in MHz, recommend be equal with VGA_CLOCK from labs/common/vga.sv
 )
 (
@@ -66,7 +66,7 @@ module board_specific_top
         .w_sw    ( w_top_sw              ),
         .w_led   ( w_led - w_digit       ),        // The last 6 LEDR are used like a 7SEG dp
         .w_digit ( w_digit               ),
-        .w_gpio  ( w_gpio                )
+        .w_gpio  ( w_gpio                )         // GPIO_0[5:0] reserved for mic
     )
     i_top
     (
@@ -211,14 +211,14 @@ module board_specific_top
     (
         .clk   ( clk        ),
         .rst   ( rst        ),
-        .lr    ( GPIO_0 [5] ), // JP1 pin 6
-        .ws    ( GPIO_0 [3] ), // JP1 pin 4
-        .sck   ( GPIO_0 [1] ), // JP1 pin 2
-        .sd    ( GPIO_0 [0] ), // JP1 pin 1
+        .lr    ( GPIO_0 [0] ), // JP1 pin 1
+        .ws    ( GPIO_0 [2] ), // JP1 pin 3
+        .sck   ( GPIO_0 [4] ), // JP1 pin 5
+        .sd    ( GPIO_0 [5] ), // JP1 pin 6
         .value ( mic        )
     );
 
-    assign GPIO_0 [4] = 1'b0;  // GND - JP1 pin 5
-    assign GPIO_0 [2] = 1'b1;  // VCC - JP1 pin 3
+    assign GPIO_0 [1] = 1'b0;  // GND - JP1 pin 2
+    assign GPIO_0 [3] = 1'b1;  // VCC - JP1 pin 4
 
 endmodule

--- a/boards/de2_115/board_specific_top.sv
+++ b/boards/de2_115/board_specific_top.sv
@@ -7,7 +7,7 @@ module board_specific_top
               w_sw      = 18,
               w_led     = 18,
               w_digit   = 8,
-              w_gpio    = 36,
+              w_gpio    = 36,        // GPIO[5:0] reserved for mic
               vga_clock = 25         // Pixel clock of VGA in MHz, recommend be equal with VGA_CLOCK from labs/common/vga.sv
 )
 (
@@ -67,7 +67,7 @@ module board_specific_top
         .w_sw    ( w_top_sw        ),
         .w_led   ( w_led - w_digit ),              // The last 8 LEDR are used like a 7SEG dp
         .w_digit ( w_digit         ),
-        .w_gpio  ( w_gpio          )
+        .w_gpio  ( w_gpio          )               // GPIO[5:0] reserved for mic
     )
     i_top
     (
@@ -223,14 +223,14 @@ module board_specific_top
     (
         .clk   ( clk      ),
         .rst   ( rst      ),
-        .lr    ( GPIO [5] ), // JP5 pin 6
-        .ws    ( GPIO [3] ), // JP5 pin 4
-        .sck   ( GPIO [1] ), // JP5 pin 2
-        .sd    ( GPIO [0] ), // JP5 pin 1
+        .lr    ( GPIO [0] ), // JP1 pin 1
+        .ws    ( GPIO [2] ), // JP1 pin 3
+        .sck   ( GPIO [4] ), // JP1 pin 5
+        .sd    ( GPIO [5] ), // JP1 pin 6
         .value ( mic      )
     );
 
-    assign GPIO [4] = 1'b0;  // GND - JP5 pin 5
-    assign GPIO [2] = 1'b1;  // VCC - JP5 pin 3
+    assign GPIO [1] = 1'b0;  // GND - JP1 pin 2
+    assign GPIO [3] = 1'b1;  // VCC - JP1 pin 4
 
 endmodule

--- a/boards/piswords6/board_specific_top.sv
+++ b/boards/piswords6/board_specific_top.sv
@@ -32,7 +32,7 @@ module board_specific_top
 
     localparam w_top_key = w_key - 1;  // One key is used as a reset
 
-    wire                   rst     = ~ KEY [w_key     - 1];
+    wire                   rst     = ~ KEY [w_top_key];
     wire [w_top_key - 1:0] top_key = ~ KEY [w_top_key - 1:0];
 
     //------------------------------------------------------------------------
@@ -91,20 +91,20 @@ module board_specific_top
 
     assign VGA_RGB = { | red, | green, | blue};
 
-    /*
+    //------------------------------------------------------------------------
+
     inmp441_mic_i2s_receiver i_microphone
     (
         .clk   ( clk       ),
         .rst   ( rst       ),
-        .lr    ( LCD_D [1] ),
-        .ws    ( LCD_D [2] ),
-        .sck   ( LCD_D [3] ),
-        .sd    ( LCD_D [6] ),
+        .lr    ( GPIO [11] ),  // P1 pin 18
+        .ws    ( GPIO [13] ),  // P1 pin 20
+        .sck   ( GPIO [15] ),  // P1 pin 22
+        .sd    ( GPIO [14] ),  // P1 pin 21
         .value ( mic       )
     );
 
-    assign LCD_D [4] = 1'b0;  // GND
-    assign LCD_D [5] = 1'b1;  // VCC
-    */
+    assign GPIO [10] = 1'b0;   // GND - P1 pin 17
+    assign GPIO [12] = 1'b1;   // VCC - P1 pin 19
 
 endmodule


### PR DESCRIPTION
c5gx, de0, de0_cv, de0_nano, de0_nano_soc, de10_lite, de10_lite_tm1638, de10_nano, de1_soc, de2_115, piswords6.