### PR TITLE
Altera boards: moved tm1638 pins close to power

### DIFF
--- a/boards/de0_nano/board_specific_top.sv
+++ b/boards/de0_nano/board_specific_top.sv
@@ -203,9 +203,9 @@ module board_specific_top
         .digit      ( tm_digit      ),
         .ledr       ( tm_led        ),
         .keys       ( tm_key        ),
-        .sio_stb    ( GPIO_0 [29]   ), // JP1 pin 36
-        .sio_clk    ( GPIO_0 [31]   ), // JP1 pin 38
-        .sio_data   ( GPIO_0 [33]   )  // JP1 pin 40
+        .sio_stb    ( GPIO_0 [25]   ), // JP1 pin 32
+        .sio_clk    ( GPIO_0 [27]   ), // JP1 pin 34
+        .sio_data   ( GPIO_0 [29]   )  // JP1 pin 36
     );                                 // JP1 pin 30 - GND, pin 29 - VCC 3.3V
 
     //------------------------------------------------------------------------

--- a/boards/de0_nano_soc/board_specific_top.sv
+++ b/boards/de0_nano_soc/board_specific_top.sv
@@ -210,9 +210,9 @@ module board_specific_top
         .digit      ( tm_digit      ),
         .ledr       ( tm_led        ),
         .keys       ( tm_key        ),
-        .sio_clk    ( GPIO_0 [31]   ), // JP1 pin 36
-        .sio_stb    ( GPIO_0 [33]   ), // JP1 pin 38
-        .sio_data   ( GPIO_0 [35]   )  // JP1 pin 40
+        .sio_clk    ( GPIO_0 [27]   ), // JP1 pin 32
+        .sio_stb    ( GPIO_0 [29]   ), // JP1 pin 34
+        .sio_data   ( GPIO_0 [31]   )  // JP1 pin 36
     );                                 // JP1 pin 30 - GND, pin 29 - VCC 3.3V
 
     //------------------------------------------------------------------------

--- a/boards/de10_lite_tm1638/board_specific_top.sv
+++ b/boards/de10_lite_tm1638/board_specific_top.sv
@@ -226,13 +226,10 @@ module board_specific_top
         .digit      ( tm_digit      ),
         .ledr       ( tm_led        ),
         .keys       ( tm_key        ),
-        .sio_stb    ( GPIO [31]     ), // JP1 pin 36
-        .sio_clk    ( GPIO [33]     ), // JP1 pin 38
-        .sio_data   ( GPIO [35]     )  // JP1 pin 40
+        .sio_stb    ( GPIO [27]     ), // JP1 pin 32
+        .sio_clk    ( GPIO [29]     ), // JP1 pin 34
+        .sio_data   ( GPIO [31]     )  // JP1 pin 36
     );                                 // JP1 pin 30 - GND, pin 29 - VCC 3.3V
-
-    assign GPIO [27] = 1'b1; // JP1 pin 32
-    assign GPIO [29] = 1'b0; // JP1 pin 34
 
     //------------------------------------------------------------------------
 

--- a/boards/de10_nano/board_specific_top.sv
+++ b/boards/de10_nano/board_specific_top.sv
@@ -209,9 +209,9 @@ module board_specific_top
         .digit      ( tm_digit      ),
         .ledr       ( tm_led        ),
         .keys       ( tm_key        ),
-        .sio_stb    ( GPIO_0 [31]   ), // JP1 pin 36
-        .sio_clk    ( GPIO_0 [33]   ), // JP1 pin 38
-        .sio_data   ( GPIO_0 [35]   )  // JP1 pin 40
+        .sio_stb    ( GPIO_0 [27]   ), // JP1 pin 32
+        .sio_clk    ( GPIO_0 [29]   ), // JP1 pin 34
+        .sio_data   ( GPIO_0 [31]   )  // JP1 pin 36
     );                                 // JP1 pin 30 - GND, pin 29 - VCC 3.3V
 
     //------------------------------------------------------------------------


### PR DESCRIPTION
DE0-Nano, DE0-Nano-SoC, DE10-Lite_TM1638, DE10-Nano.