### PR TITLE
Rewrote top wrapper all tm1638 and static 7SEG boards to config.svh

### DIFF
--- a/boards/arty_a7/board_specific_top.sv
+++ b/boards/arty_a7/board_specific_top.sv
@@ -1,8 +1,4 @@
-// `define EMULATE_DYNAMIC_7SEG_WITHOUT_STICKY_FLOPS
-
-   `define DUPLICATE_TM_SIGNALS_WITH_REGULAR
-// `define CONCAT_REGULAR_SIGNALS_AND_TM
-// `define CONCAT_TM_SIGNALS_AND_REGULAR
+`include "config.svh"
 
 module board_specific_top
 # (
@@ -195,17 +191,6 @@ localparam  w_tm_key     = 8,
         end
     endgenerate
 
-`ifdef EMULATE_DYNAMIC_7SEG_WITHOUT_STICKY_FLOPS
-
-        // Con: This makes blink the 7-segment LEDs of TM1638
-
-        wire tm_static_hex;
-        assign tm_static_hex = 'b0;
-    `else
-        wire tm_static_hex;
-        assign tm_static_hex = 'b1;
-    `endif
-
 tm1638_board_controller
     # (
         .w_digit ( w_tm_digit ),        // fake parameter, digit count is hardcode in tm1638_board_controller
@@ -215,7 +200,6 @@ tm1638_board_controller
     (
         .clk        ( clk           ), 
         .rst        ( rst           ),
-        .static_hex ( tm_static_hex ),
         .hgfedcba   ( hgfedcba      ),
         .digit      ( tm_digit      ),
         .ledr       ( tm_led        ),

--- a/boards/c5gx/board_specific_top.sv
+++ b/boards/c5gx/board_specific_top.sv
@@ -1,4 +1,4 @@
-// `define EMULATE_DYNAMIC_7SEG_WITHOUT_STICKY_FLOPS
+`include "config.svh"
 
 module board_specific_top
 # (

--- a/boards/de0/board_specific_top.sv
+++ b/boards/de0/board_specific_top.sv
@@ -1,4 +1,4 @@
-// `define EMULATE_DYNAMIC_7SEG_WITHOUT_STICKY_FLOPS
+`include "config.svh"
 
 module board_specific_top
 # (

--- a/boards/de0_cv/board_specific_top.sv
+++ b/boards/de0_cv/board_specific_top.sv
@@ -1,4 +1,4 @@
-// `define EMULATE_DYNAMIC_7SEG_WITHOUT_STICKY_FLOPS
+`include "config.svh"
 
 module board_specific_top
 # (

--- a/boards/de0_nano/board_specific_top.sv
+++ b/boards/de0_nano/board_specific_top.sv
@@ -1,8 +1,4 @@
-// `define EMULATE_DYNAMIC_7SEG_WITHOUT_STICKY_FLOPS
-
-   `define DUPLICATE_TM_SIGNALS_WITH_REGULAR
-// `define CONCAT_REGULAR_SIGNALS_AND_TM
-// `define CONCAT_TM_SIGNALS_AND_REGULAR
+`include "config.svh"
 
 module board_specific_top
 # (
@@ -177,19 +173,6 @@ module board_specific_top
 
     //------------------------------------------------------------------------
 
-    `ifdef EMULATE_DYNAMIC_7SEG_WITHOUT_STICKY_FLOPS
-
-        // Con: This makes blink the 7-segment LEDs of TM1638
-
-        wire tm_static_hex;
-        assign tm_static_hex = 'b0;
-    `else
-        wire tm_static_hex;
-        assign tm_static_hex = 'b1;
-    `endif
-
-    //------------------------------------------------------------------------
-
     tm1638_board_controller
     # (
         .w_digit ( w_tm_digit )        // fake parameter, digit count is hardcode in tm1638_board_controller
@@ -198,7 +181,6 @@ module board_specific_top
     (
         .clk        ( clk           ),
         .rst        ( rst           ), // Don't make reset tm1638_board_controller by it's tm_key
-        .static_hex ( tm_static_hex ),
         .hgfedcba   ( hgfedcba      ),
         .digit      ( tm_digit      ),
         .ledr       ( tm_led        ),

--- a/boards/de0_nano_alt_vga/board_specific_top.sv
+++ b/boards/de0_nano_alt_vga/board_specific_top.sv
@@ -1,8 +1,4 @@
-// `define EMULATE_DYNAMIC_7SEG_WITHOUT_STICKY_FLOPS
-
-   `define DUPLICATE_TM_SIGNALS_WITH_REGULAR
-// `define CONCAT_REGULAR_SIGNALS_AND_TM
-// `define CONCAT_TM_SIGNALS_AND_REGULAR
+`include "config.svh"
 
 module board_specific_top
 # (
@@ -177,19 +173,6 @@ module board_specific_top
 
     //------------------------------------------------------------------------
 
-    `ifdef EMULATE_DYNAMIC_7SEG_WITHOUT_STICKY_FLOPS
-
-        // Con: This makes blink the 7-segment LEDs of TM1638
-
-        wire tm_static_hex;
-        assign tm_static_hex = 'b0;
-    `else
-        wire tm_static_hex;
-        assign tm_static_hex = 'b1;
-    `endif
-
-    //------------------------------------------------------------------------
-
     tm1638_board_controller
     # (
         .w_digit ( w_tm_digit )        // fake parameter, digit count is hardcode in tm1638_board_controller
@@ -198,7 +181,6 @@ module board_specific_top
     (
         .clk        ( clk           ),
         .rst        ( rst           ), // Don't make reset tm1638_board_controller by it's tm_key
-        .static_hex ( tm_static_hex ),
         .hgfedcba   ( hgfedcba      ),
         .digit      ( tm_digit      ),
         .ledr       ( tm_led        ),

--- a/boards/de0_nano_soc/board_specific_top.sv
+++ b/boards/de0_nano_soc/board_specific_top.sv
@@ -1,8 +1,4 @@
-// `define EMULATE_DYNAMIC_7SEG_WITHOUT_STICKY_FLOPS
-
-   `define DUPLICATE_TM_SIGNALS_WITH_REGULAR
-// `define CONCAT_REGULAR_SIGNALS_AND_TM
-// `define CONCAT_TM_SIGNALS_AND_REGULAR
+`include "config.svh"
 
 module board_specific_top
 # (
@@ -184,19 +180,6 @@ module board_specific_top
 
     //------------------------------------------------------------------------
 
-    `ifdef EMULATE_DYNAMIC_7SEG_WITHOUT_STICKY_FLOPS
-
-        // Con: This makes blink the 7-segment LEDs of TM1638
-
-        wire tm_static_hex;
-        assign tm_static_hex = 'b0;
-    `else
-        wire tm_static_hex;
-        assign tm_static_hex = 'b1;
-    `endif
-
-    //------------------------------------------------------------------------
-
     tm1638_board_controller
     # (
         .w_digit ( w_tm_digit )        // fake parameter, digit count is hardcode in tm1638_board_controller
@@ -205,7 +188,6 @@ module board_specific_top
     (
         .clk        ( clk           ),
         .rst        ( rst           ), // Don't make reset tm1638_board_controller by it's tm_key
-        .static_hex ( tm_static_hex ),
         .hgfedcba   ( hgfedcba      ),
         .digit      ( tm_digit      ),
         .ledr       ( tm_led        ),

--- a/boards/de10_lite/board_specific_top.sv
+++ b/boards/de10_lite/board_specific_top.sv
@@ -1,4 +1,4 @@
-// `define EMULATE_DYNAMIC_7SEG_WITHOUT_STICKY_FLOPS
+`include "config.svh"
 
 module board_specific_top
 # (

--- a/boards/de10_nano/board_specific_top.sv
+++ b/boards/de10_nano/board_specific_top.sv
@@ -1,8 +1,4 @@
-// `define EMULATE_DYNAMIC_7SEG_WITHOUT_STICKY_FLOPS
-
-   `define DUPLICATE_TM_SIGNALS_WITH_REGULAR
-// `define CONCAT_REGULAR_SIGNALS_AND_TM
-// `define CONCAT_TM_SIGNALS_AND_REGULAR
+`include "config.svh"
 
 module board_specific_top
 # (
@@ -183,19 +179,6 @@ module board_specific_top
 
     //------------------------------------------------------------------------
 
-    `ifdef EMULATE_DYNAMIC_7SEG_WITHOUT_STICKY_FLOPS
-
-        // Con: This makes blink the 7-segment LEDs of TM1638
-
-        wire tm_static_hex;
-        assign tm_static_hex = 'b0;
-    `else
-        wire tm_static_hex;
-        assign tm_static_hex = 'b1;
-    `endif
-
-    //------------------------------------------------------------------------
-
     tm1638_board_controller
     # (
         .w_digit ( w_tm_digit )        // fake parameter, digit count is hardcode in tm1638_board_controller
@@ -204,7 +187,6 @@ module board_specific_top
     (
         .clk        ( clk           ),
         .rst        ( rst           ), // Don't make reset tm1638_board_controller by it's tm_key
-        .static_hex ( tm_static_hex ),
         .hgfedcba   ( hgfedcba      ),
         .digit      ( tm_digit      ),
         .ledr       ( tm_led        ),

--- a/boards/de1_soc/board_specific_top.sv
+++ b/boards/de1_soc/board_specific_top.sv
@@ -1,4 +1,4 @@
-// `define EMULATE_DYNAMIC_7SEG_WITHOUT_STICKY_FLOPS
+`include "config.svh"
 
 module board_specific_top
 # (

--- a/boards/de2_115/board_specific_top.sv
+++ b/boards/de2_115/board_specific_top.sv
@@ -1,4 +1,4 @@
-// `define EMULATE_DYNAMIC_7SEG_WITHOUT_STICKY_FLOPS
+`include "config.svh"
 
 module board_specific_top
 # (

--- a/boards/dk_dev_3c120n/board_specific_top.sv
+++ b/boards/dk_dev_3c120n/board_specific_top.sv
@@ -1,4 +1,4 @@
-// `define EMULATE_DYNAMIC_7SEG_WITHOUT_STICKY_FLOPS
+`include "config.svh"
 
 module board_specific_top
 # (

--- a/boards/tang_nano_9k/board_specific_top.sv
+++ b/boards/tang_nano_9k/board_specific_top.sv
@@ -1,4 +1,4 @@
-//   `define ENABLE_TM1638
+`include "config.svh"
 
 module board_specific_top
 # (
@@ -31,6 +31,13 @@ module board_specific_top
 
     //------------------------------------------------------------------------
 
+    localparam w_top_sw   = w_sw - 1;  // One onboard SW is used as a reset
+
+    wire                  rst     = SW [w_top_sw];
+    wire [w_top_sw - 1:0] top_sw  = SW [w_top_sw - 1:0];
+
+    //------------------------------------------------------------------------
+
     localparam w_tm_key    = 8,
                w_tm_led    = 8,
                w_tm_digit  = 8;
@@ -38,20 +45,17 @@ module board_specific_top
 
     //------------------------------------------------------------------------
 
-    `ifdef ENABLE_TM1638    // TM1638 module is connected
+    `ifdef DUPLICATE_TM_SIGNALS_WITH_REGULAR
 
-        localparam w_top_key   = w_tm_key,
-                   w_top_sw    = w_sw,
-                   w_top_led   = w_tm_led,
-                   w_top_digit = w_tm_digit;
+        localparam w_top_key   = w_tm_key   > w_key   ? w_tm_key   : w_key   ,
+                   w_top_led   = w_tm_led   > w_led   ? w_tm_led   : w_led   ,
+                   w_top_digit = w_tm_digit > w_digit ? w_tm_digit : w_digit ;
 
-    `else                   // TM1638 module is not connected
+    `else  // Concatenate the signals
 
-        localparam w_top_key   = w_key,
-                   w_top_sw    = w_sw,
-                   w_top_led   = w_led,
-                   w_top_digit = w_digit;
-
+        localparam w_top_key   = w_tm_key   + w_key   ,
+                   w_top_led   = w_tm_led   + w_led   ,
+                   w_top_digit = w_tm_digit + w_digit ;
     `endif
 
     //------------------------------------------------------------------------
@@ -64,26 +68,40 @@ module board_specific_top
     wire  [w_top_led   - 1:0] top_led;
     wire  [w_top_digit - 1:0] top_digit;
 
-    wire                      rst;
     wire  [              7:0] abcdefgh;
     wire  [             23:0] mic;
 
-   //------------------------------------------------------------------------
+    //------------------------------------------------------------------------
 
-    `ifdef ENABLE_TM1638    // TM1638 module is connected
+    `ifdef CONCAT_TM_SIGNALS_AND_REGULAR
 
-        assign rst      = tm_key [w_tm_key - 1];
-        assign top_key  = tm_key [w_tm_key - 1:0];
+        assign top_key = { tm_key, ~ KEY };
 
-        assign tm_led   = top_led;
-        assign tm_digit = top_digit;
+        assign { tm_led   , LED   } = { top_led[w_tm_led - 1:w_led], ~ top_led[w_led    - 1:0] };
+        assign { tm_digit , digit } = top_digit;
 
-    `else                   // TM1638 module is not connected
+    `elsif CONCAT_REGULAR_SIGNALS_AND_TM
 
-        assign rst      = ~ KEY [w_key - 1];
-        assign top_key  = ~ KEY [w_key - 1:0];
+        assign top_key = { ~ KEY, tm_key };
 
-        assign LED      = ~ top_led;
+        assign { LED   , tm_led   } = { ~ top_led[w_led    - 1:w_tm_led], top_led[w_tm_led - 1:0] };
+        assign { digit , tm_digit } = top_digit;
+
+    `else  // DUPLICATE_TM_SIGNALS_WITH_REGULAR
+
+        always_comb
+        begin
+            top_key = '0;
+
+            top_key [w_key    - 1:0] |= ~ KEY;
+            top_key [w_tm_key - 1:0] |= tm_key;
+        end
+
+        assign LED      = ~ top_led   [w_led      - 1:0];
+        assign tm_led   =   top_led   [w_tm_led   - 1:0];
+
+        assign digit    = top_digit [w_digit    - 1:0];
+        assign tm_digit = top_digit [w_tm_digit - 1:0];
 
     `endif
 
@@ -144,7 +162,7 @@ module board_specific_top
     i_tm1638
     (
         .clk      ( CLK       ),
-        .rst      ( rst       ),
+        .rst      ( rst       ), // Don't make reset tm1638_board_controller by it's tm_key
         .hgfedcba ( hgfedcba  ),
         .digit    ( tm_digit  ),
         .ledr     ( tm_led    ),

--- a/boards/tang_primer_20k_dock/board_specific_top.sv
+++ b/boards/tang_primer_20k_dock/board_specific_top.sv
@@ -1,6 +1,4 @@
-// `define EMULATE_DYNAMIC_7SEG_WITHOUT_STICKY_FLOPS
-
-   `define ENABLE_TM1638
+`include "config.svh"
 
 module board_specific_top
 # (
@@ -30,26 +28,30 @@ module board_specific_top
 
     //------------------------------------------------------------------------
 
+    localparam w_top_sw   = w_sw - 1;  // One onboard SW is used as a reset
+
+    wire                  rst     = SW [w_top_sw];
+    wire [w_top_sw - 1:0] top_sw  = SW [w_top_sw - 1:0];
+
+    //------------------------------------------------------------------------
+
     localparam w_tm_key    = 8,
                w_tm_led    = 8,
                w_tm_digit  = 8;
 
     //------------------------------------------------------------------------
 
-    `ifdef ENABLE_TM1638    // TM1638 module is connected
+    `ifdef DUPLICATE_TM_SIGNALS_WITH_REGULAR
 
-        localparam w_top_key   = w_tm_key,
-                   w_top_sw    = w_sw,
-                   w_top_led   = w_tm_led,
-                   w_top_digit = w_tm_digit;
+        localparam w_top_key   = w_tm_key   > w_key   ? w_tm_key   : w_key   ,
+                   w_top_led   = w_tm_led   > w_led   ? w_tm_led   : w_led   ,
+                   w_top_digit = w_tm_digit > w_digit ? w_tm_digit : w_digit ;
 
-    `else                   // TM1638 module is not connected
+    `else  // Concatenate the signals
 
-        localparam w_top_key   = w_key,
-                   w_top_sw    = w_sw,
-                   w_top_led   = w_led,
-                   w_top_digit = w_digit;
-
+        localparam w_top_key   = w_tm_key   + w_key   ,
+                   w_top_led   = w_tm_led   + w_led   ,
+                   w_top_digit = w_tm_digit + w_digit ;
     `endif
 
     //------------------------------------------------------------------------
@@ -59,11 +61,9 @@ module board_specific_top
     wire  [w_tm_digit  - 1:0] tm_digit;
 
     logic [w_top_key   - 1:0] top_key;
-    logic [w_top_sw    - 1:0] top_sw;
     wire  [w_top_led   - 1:0] top_led;
     wire  [w_top_digit - 1:0] top_digit;
 
-    wire                      rst;
     wire  [              7:0] abcdefgh;
     wire  [             23:0] mic;
 
@@ -76,22 +76,35 @@ module board_specific_top
 
     //------------------------------------------------------------------------
 
-    `ifdef ENABLE_TM1638    // TM1638 module is connected
+    `ifdef CONCAT_TM_SIGNALS_AND_REGULAR
 
-        assign rst      = tm_key [w_tm_key - 1];
-        assign top_key  = tm_key [w_tm_key - 1:0];
-        assign top_sw   = ~ SW;
+        assign top_key = { tm_key, ~ KEY };
 
-        assign tm_led   = top_led;
-        assign tm_digit = top_digit;
+        assign { tm_led   , LED   } = { top_led[w_tm_led - 1:w_led], ~ top_led[w_led    - 1:0] };
+        assign { tm_digit , digit } = top_digit;
 
-    `else                   // TM1638 module is not connected
+    `elsif CONCAT_REGULAR_SIGNALS_AND_TM
 
-        assign rst      = ~ KEY [w_key - 1];
-        assign top_key  = ~ KEY [w_key - 1:0];
-        assign top_sw   = ~ SW;
+        assign top_key = { ~ KEY, tm_key };
 
-        assign LED      = ~ top_led;
+        assign { LED   , tm_led   } = { ~ top_led[w_led    - 1:w_tm_led], top_led[w_tm_led - 1:0] };
+        assign { digit , tm_digit } = top_digit;
+
+    `else  // DUPLICATE_TM_SIGNALS_WITH_REGULAR
+
+        always_comb
+        begin
+            top_key = '0;
+
+            top_key [w_key    - 1:0] |= ~ KEY;
+            top_key [w_tm_key - 1:0] |= tm_key;
+        end
+
+        assign LED      = ~ top_led   [w_led      - 1:0];
+        assign tm_led   =   top_led   [w_tm_led   - 1:0];
+
+        assign digit    = top_digit [w_digit    - 1:0];
+        assign tm_digit = top_digit [w_tm_digit - 1:0];
 
     `endif
 
@@ -145,19 +158,6 @@ module board_specific_top
 
     //------------------------------------------------------------------------
 
-    `ifdef EMULATE_DYNAMIC_7SEG_WITHOUT_STICKY_FLOPS
-
-        // Con: This makes blink the 7-segment LEDs of TM1638
-
-        wire tm_static_hex;
-        assign tm_static_hex = 'b0;
-    `else
-        wire tm_static_hex;
-        assign tm_static_hex = 'b1;
-    `endif
-
-    //------------------------------------------------------------------------
-
     tm1638_board_controller
     # (
         .w_digit ( w_tm_digit )
@@ -166,7 +166,6 @@ module board_specific_top
     (
         .clk        ( CLK           ),
         .rst        ( rst           ),
-        .static_hex ( tm_static_hex ),
         .hgfedcba   ( hgfedcba      ),
         .digit      ( tm_digit      ),
         .ledr       ( tm_led        ),

--- a/boards/tang_primer_20k_dock_alt/board_specific_top.sv
+++ b/boards/tang_primer_20k_dock_alt/board_specific_top.sv
@@ -1,6 +1,4 @@
-// `define EMULATE_DYNAMIC_7SEG_WITHOUT_STICKY_FLOPS
-
-   `define ENABLE_TM1638
+`include "config.svh"
 
 module board_specific_top
 # (
@@ -30,26 +28,30 @@ module board_specific_top
 
     //------------------------------------------------------------------------
 
+    localparam w_top_sw   = w_sw - 1;  // One onboard SW is used as a reset
+
+    wire                  rst     = SW [w_top_sw];
+    wire [w_top_sw - 1:0] top_sw  = SW [w_top_sw - 1:0];
+
+    //------------------------------------------------------------------------
+
     localparam w_tm_key    = 8,
                w_tm_led    = 8,
                w_tm_digit  = 8;
 
     //------------------------------------------------------------------------
 
-    `ifdef ENABLE_TM1638    // TM1638 module is connected
+    `ifdef DUPLICATE_TM_SIGNALS_WITH_REGULAR
 
-        localparam w_top_key   = w_tm_key,
-                   w_top_sw    = w_sw,
-                   w_top_led   = w_tm_led,
-                   w_top_digit = w_tm_digit;
+        localparam w_top_key   = w_tm_key   > w_key   ? w_tm_key   : w_key   ,
+                   w_top_led   = w_tm_led   > w_led   ? w_tm_led   : w_led   ,
+                   w_top_digit = w_tm_digit > w_digit ? w_tm_digit : w_digit ;
 
-    `else                   // TM1638 module is not connected
+    `else  // Concatenate the signals
 
-        localparam w_top_key   = w_key,
-                   w_top_sw    = w_sw,
-                   w_top_led   = w_led,
-                   w_top_digit = w_digit;
-
+        localparam w_top_key   = w_tm_key   + w_key   ,
+                   w_top_led   = w_tm_led   + w_led   ,
+                   w_top_digit = w_tm_digit + w_digit ;
     `endif
 
     //------------------------------------------------------------------------
@@ -59,11 +61,9 @@ module board_specific_top
     wire  [w_tm_digit  - 1:0] tm_digit;
 
     logic [w_top_key   - 1:0] top_key;
-    logic [w_top_sw    - 1:0] top_sw;
     wire  [w_top_led   - 1:0] top_led;
     wire  [w_top_digit - 1:0] top_digit;
 
-    wire                      rst;
     wire  [              7:0] abcdefgh;
     wire  [             23:0] mic;
 
@@ -76,22 +76,35 @@ module board_specific_top
 
     //------------------------------------------------------------------------
 
-    `ifdef ENABLE_TM1638    // TM1638 module is connected
+    `ifdef CONCAT_TM_SIGNALS_AND_REGULAR
 
-        assign rst      = tm_key [w_tm_key - 1];
-        assign top_key  = tm_key [w_tm_key - 1:0];
-        assign top_sw   = ~ SW;
+        assign top_key = { tm_key, ~ KEY };
 
-        assign tm_led   = top_led;
-        assign tm_digit = top_digit;
+        assign { tm_led   , LED   } = { top_led[w_tm_led - 1:w_led], ~ top_led[w_led    - 1:0] };
+        assign { tm_digit , digit } = top_digit;
 
-    `else                   // TM1638 module is not connected
+    `elsif CONCAT_REGULAR_SIGNALS_AND_TM
 
-        assign rst      = ~ KEY [w_key - 1];
-        assign top_key  = ~ KEY [w_key - 1:0];
-        assign top_sw   = ~ SW;
+        assign top_key = { ~ KEY, tm_key };
 
-        assign LED      = ~ top_led;
+        assign { LED   , tm_led   } = { ~ top_led[w_led    - 1:w_tm_led], top_led[w_tm_led - 1:0] };
+        assign { digit , tm_digit } = top_digit;
+
+    `else  // DUPLICATE_TM_SIGNALS_WITH_REGULAR
+
+        always_comb
+        begin
+            top_key = '0;
+
+            top_key [w_key    - 1:0] |= ~ KEY;
+            top_key [w_tm_key - 1:0] |= tm_key;
+        end
+
+        assign LED      = ~ top_led   [w_led      - 1:0];
+        assign tm_led   =   top_led   [w_tm_led   - 1:0];
+
+        assign digit    = top_digit [w_digit    - 1:0];
+        assign tm_digit = top_digit [w_tm_digit - 1:0];
 
     `endif
 
@@ -145,19 +158,6 @@ module board_specific_top
 
     //------------------------------------------------------------------------
 
-    `ifdef EMULATE_DYNAMIC_7SEG_WITHOUT_STICKY_FLOPS
-
-        // Con: This makes blink the 7-segment LEDs of TM1638
-
-        wire tm_static_hex;
-        assign tm_static_hex = 'b0;
-    `else
-        wire tm_static_hex;
-        assign tm_static_hex = 'b1;
-    `endif
-
-    //------------------------------------------------------------------------
-
     tm1638_board_controller
     # (
         .w_digit ( w_tm_digit )
@@ -165,8 +165,7 @@ module board_specific_top
     i_tm1638
     (
         .clk        ( CLK           ),
-        .rst        ( rst           ),
-        .static_hex ( tm_static_hex ),
+        .rst        ( rst           ), // Don't make reset tm1638_board_controller by it's tm_key
         .hgfedcba   ( hgfedcba      ),
         .digit      ( tm_digit      ),
         .ledr       ( tm_led        ),

--- a/boards/zybo_z7/board_specific_top.sv
+++ b/boards/zybo_z7/board_specific_top.sv
@@ -1,4 +1,4 @@
-`define DUPLICATE_TM_SIGNALS_WITH_REGULAR
+`include "config.svh"
 
 module board_specific_top
 # (
@@ -18,67 +18,73 @@ module board_specific_top
     inout  [w_gpio      - 1:0] gpio_JE
 );
 
-    logic [              7:0] abcdefgh;
-    wire  [w_digit     - 1:0] digit;
+    //------------------------------------------------------------------------
 
     localparam w_sw_top = w_sw - 1;  // One sw is used as a reset
 
     wire rst = sw[w_sw - 1];         // Last switch is used as a reset
     wire [w_sw_top - 1:0] sw_top  = sw[w_sw_top - 1:0];
 
+    //------------------------------------------------------------------------
+
+    logic [              7:0] abcdefgh;
+    wire  [w_digit     - 1:0] digit;
+
+    //------------------------------------------------------------------------
 
     localparam w_key_tm   = 8,
                w_led_tm   = 8,
                w_digit_tm = 8;
 
-`ifdef DUPLICATE_TM_SIGNALS_WITH_REGULAR
-    localparam w_key_top   = w_key_tm   > w_key   ? w_key_tm   : w_key,
-               w_led_top   = w_led_tm   > w_led   ? w_led_tm   : w_led,
-               w_digit_top = w_digit_tm > w_digit ? w_digit_tm : w_digit;
-`else
-    localparam w_key_top   = w_key_tm   + w_key,
-               w_led_top   = w_led_tm   + w_led,
-               w_digit_top = w_digit_tm + w_digit;
-`endif
+    //------------------------------------------------------------------------
 
+    `ifdef DUPLICATE_TM_SIGNALS_WITH_REGULAR
+        localparam w_key_top   = w_key_tm   > w_key   ? w_key_tm   : w_key,
+                w_led_top   = w_led_tm   > w_led   ? w_led_tm   : w_led,
+                w_digit_top = w_digit_tm > w_digit ? w_digit_tm : w_digit;
+    `else
+        localparam w_key_top   = w_key_tm   + w_key,
+                w_led_top   = w_led_tm   + w_led,
+                w_digit_top = w_digit_tm + w_digit;
+    `endif
 
-//------------------------------------------------------------------------------
+    //------------------------------------------------------------------------------
 
-    wire  [w_key_tm    - 1:0] key_tm;
-    wire  [w_led_tm    - 1:0] led_tm;
-    wire  [w_digit_tm  - 1:0] digit_tm;
+        wire  [w_key_tm    - 1:0] key_tm;
+        wire  [w_led_tm    - 1:0] led_tm;
+        wire  [w_digit_tm  - 1:0] digit_tm;
 
-    logic [w_key_top   - 1:0] key_top;
-    wire  [w_led_top   - 1:0] led_top;
-    wire  [w_digit_top - 1:0] digit_top;
+        logic [w_key_top   - 1:0] key_top;
+        wire  [w_led_top   - 1:0] led_top;
+        wire  [w_digit_top - 1:0] digit_top;
 
-//------------------------------------------------------------------------------
+    //------------------------------------------------------------------------------
 
-`ifdef CONCAT_TM_SIGNALS_AND_REGULAR
-    assign key_top = {key_tm, key};
-    assign {led_tm, led} = led_top;
-    assign {digit_tm, digit} = digit_top;
+    `ifdef CONCAT_TM_SIGNALS_AND_REGULAR
+        assign key_top = {key_tm, key};
+        assign {led_tm, led} = led_top;
+        assign {digit_tm, digit} = digit_top;
 
-`elsif CONCAT_REGULAR_SIGNALS_AND_TM
-    assign key_top = {key, key_tm};
-    assign {led, led_tm} = led_top;
-    assign {digit, digit_tm} = digit_top;
+    `elsif CONCAT_REGULAR_SIGNALS_AND_TM
+        assign key_top = {key, key_tm};
+        assign {led, led_tm} = led_top;
+        assign {digit, digit_tm} = digit_top;
 
-`else  // DUPLICATE_TM_SIGNALS_WITH_REGULAR
-    always_comb
-    begin
-        key_top = '0;
-        key_top[w_key - 1:0] |= key;
-        key_top[w_key_tm - 1:0] |= key_tm;
-    end
+    `else  // DUPLICATE_TM_SIGNALS_WITH_REGULAR
+        always_comb
+        begin
+            key_top = '0;
+            key_top[w_key - 1:0] |= key;
+            key_top[w_key_tm - 1:0] |= key_tm;
+        end
 
-    assign led = led_top[w_led - 1:0];
-    assign led_tm = led_top[w_led_tm - 1:0];
-    assign digit = digit_top[0:0];
-    assign digit_tm = digit_top[w_digit_tm - 1:0];
-`endif
+        assign led = led_top[w_led - 1:0];
+        assign led_tm = led_top[w_led_tm - 1:0];
+        assign digit = digit_top[0:0];
+        assign digit_tm = digit_top[w_digit_tm - 1:0];
+    `endif
 
-//------------------------------------------------------------------------------
+    //------------------------------------------------------------------------------
 
     top
     # (
@@ -125,17 +131,17 @@ module board_specific_top
     endgenerate
 
 
-//------------------------------------------------------------------------------
+    //------------------------------------------------------------------------------
 
     tm1638_board_controller
     # (
         .clk_mhz  (clk_mhz),
-        .w_digit  (w_digit_tm)
+        .w_digit  (w_digit_tm)        // fake parameter, digit count is hardcode in tm1638_board_controller
     )
     i_tm1638
     (
         .clk      (clk_125),
-        .rst      (rst),
+        .rst      (rst),              // Don't make reset tm1638_board_controller by it's tm_key
         .hgfedcba (hgfedcba),
         .digit    (digit_tm),
         .ledr     (led_tm),


### PR DESCRIPTION
In arty_a7, de0_nano, de0_nano_alt_vga, de0_nano_soc, de10_lite_tm1638, de10_nano, tang_nano_20k, tang_nano_9k, tang_primer_20k_dock, zybo_z7 wrapper with tm1638 connections rewritten.
In c5gx, de0, de0_cv, de10_lite, de1_soc, de2_115, dk_dev_3c120n only "include "config.svh"" added.
In tang_nano_20k wrapper with tm1638 connections rewritten, VGA fix.