### PR TITLE
ice40hx8k_evb_yosys: Bugfixes:

### DIFF
--- a/boards/ice40hx8k_evb_yosys/board_specific_top.sv
+++ b/boards/ice40hx8k_evb_yosys/board_specific_top.sv
@@ -1,4 +1,5 @@
-   `define ENABLE_TM1638
+//   `define ENABLE_TM1638
+//   `define ENABLE_INMP441
 
 // 
 module board_specific_top
@@ -120,7 +121,11 @@ module board_specific_top
         .blue     ( VGA_B     ),
 
         .mic      ( mic       ),
+        `ifndef ENABLE_TM1638
+        .gpio     ( GPIO      )
+        `else
         .gpio     (           )
+        `endif
     );
 
     //------------------------------------------------------------------------
@@ -138,6 +143,7 @@ module board_specific_top
 
     //------------------------------------------------------------------------
 
+`ifdef ENABLE_TM1638
     tm1638_board_controller
     # (
         .w_digit ( w_tm_digit )
@@ -154,12 +160,14 @@ module board_specific_top
         .sio_stb  ( GPIO [1]  ),
         .sio_data ( GPIO [2]  )
     );
+`endif
 
     //------------------------------------------------------------------------
 
+`ifdef ENABLE_INMP441
     inmp441_mic_i2s_receiver i_microphone
     (
-        .clk   ( clk      ),
+        .clk   ( CLK      ),
         .rst   ( rst      ),
         .lr    ( GPIO [5] ),
         .ws    ( GPIO [4] ),
@@ -167,8 +175,6 @@ module board_specific_top
         .sd    ( GPIO [6] ),
         .value ( mic      )
     );
-
-    assign GPIO [8] = 1'b0;  // GND
-    assign GPIO [7] = 1'b1;  // VCC
+`endif
 
 endmodule


### PR DESCRIPTION
- fix GPIO assigment
- add ifdefs for TM1638 and INMP441, make them disabled by default
- set proper CLK for inmp441_mic_i2s_receiver module