### PR TITLE
Remove --reset while upoading to SRAM

### DIFF
--- a/boards/tang_nano_9k_gowin_yosys/Makefile
+++ b/boards/tang_nano_9k_gowin_yosys/Makefile
@@ -27,7 +27,7 @@ upload_openloader:
 ifeq ("$(FLASH_METHOD)", "flash")
 	openFPGALoader -v -b tangnano -f --reset --file-type fs $(NAME).bin
 else
-	openFPGALoader -v -b tangnano --reset --file-type fs $(NAME).bin
+	openFPGALoader -v -b tangnano --file-type fs $(NAME).bin
 endif
 
 fw: $(NAME).bin


### PR DESCRIPTION
'--resent' was mistakenly used while uploading to SRAM over openFPGALoader.