### PR TITLE
change scripts for vivado gui

### DIFF
--- a/scripts/fpga/xilinx_vivado_synthesize.tcl
+++ b/scripts/fpga/xilinx_vivado_synthesize.tcl
@@ -8,6 +8,10 @@ if {! [info exists part_name]} {
 }
 
 set extra_dot_dot ""
+create_project  board_specific_top ./gui_prj           \
+               -part $part_name                        \
+               -force                                  \
+               -quiet
 
 if {[file isdirectory ../../../../labs]} {
     set extra_dot_dot ../

--- a/scripts/steps/00_setup_xilinx.source_bash
+++ b/scripts/steps/00_setup_xilinx.source_bash
@@ -236,7 +236,9 @@ run_fpga_synthesis_gui_xilinx ()
 {
     is_command_available_or_error vivado " from Xilinx package"
 
-    if   [    -f post_route.dcp ] ; then
+    if   [    -f ./gui_prj/board_specific_top.xpr ] ; then
+          vivado ./gui_prj/board_specific_top.xpr &
+    elif [    -f post_route.dcp ] ; then
           vivado post_route.dcp &
     elif [    -f post_place.dcp ] ; then
           vivado post_place.dcp &


### PR DESCRIPTION
Добрый день, т.к для отображения результатов синтеза/имплементации в gui проекте Vivado, необходимо использовать project_flow с использованием runs, я решил не менять основной костяк скриптов и добавить простое создание проекта в директории run/gui_prj перед запуском non_project_flow(checkpoints), чтобы в последствии можно было открыть его скриптом .05. 

При желании пользователь может открыть чекпоинты в Vivado_GUI:
![image](https://github.com/yuri-panchul/basics-graphics-music/assets/109079011/719b3bf6-1544-45de-ace0-c923851304d3)
 
Так же пользователю придётся полностью воспроизводить все шаги до generate_bitsream в Vivado_Gui. Но сейчас в Quartus flow после запуска скрипта ./03, результаты синтеза и имплементации не видны при включении ./05 и так же приходится повторно воспроизводить все шаги.