### PR TITLE
Pass clm_mhz to tm1638_board_controller module which was missing in a number of board files.

### DIFF
--- a/boards/de0_nano_soc_vga666/board_specific_top.sv
+++ b/boards/de0_nano_soc_vga666/board_specific_top.sv
@@ -244,6 +244,7 @@ module board_specific_top
 
     tm1638_board_controller
     # (
+        .clk_mhz ( clk_mhz    ),
         .w_digit ( w_tm_digit )        // fake parameter, digit count is hardcode in tm1638_board_controller
     )
     i_ledkey

--- a/boards/de0_nano_soc_vga_pmod/board_specific_top.sv
+++ b/boards/de0_nano_soc_vga_pmod/board_specific_top.sv
@@ -236,6 +236,7 @@ module board_specific_top
 
     tm1638_board_controller
     # (
+        .clk_mhz ( clk_mhz    ),
         .w_digit ( w_tm_digit )        // fake parameter, digit count is hardcode in tm1638_board_controller
     )
     i_ledkey

--- a/boards/de0_nano_vga666/board_specific_top.sv
+++ b/boards/de0_nano_vga666/board_specific_top.sv
@@ -243,6 +243,7 @@ module board_specific_top
 
     tm1638_board_controller
     # (
+        .clk_mhz ( clk_mhz    ),
         .w_digit ( w_tm_digit )        // fake parameter, digit count is hardcode in tm1638_board_controller
     )
     i_ledkey

--- a/boards/de0_nano_vga_pmod/board_specific_top.sv
+++ b/boards/de0_nano_vga_pmod/board_specific_top.sv
@@ -243,6 +243,7 @@ module board_specific_top
 
     tm1638_board_controller
     # (
+        .clk_mhz ( clk_mhz    ),
         .w_digit ( w_tm_digit )        // fake parameter, digit count is hardcode in tm1638_board_controller
     )
     i_ledkey

--- a/boards/de10_lite_tm1638_arduino/board_specific_top.sv
+++ b/boards/de10_lite_tm1638_arduino/board_specific_top.sv
@@ -223,6 +223,7 @@ module board_specific_top
 
     tm1638_board_controller
     # (
+        .clk_mhz ( clk_mhz    ),
         .w_digit ( w_tm_digit )        // fake parameter, digit count is hardcode in tm1638_board_controller
     )
     i_ledkey

--- a/boards/de10_nano_vga666/board_specific_top.sv
+++ b/boards/de10_nano_vga666/board_specific_top.sv
@@ -265,6 +265,7 @@ module board_specific_top
 
     tm1638_board_controller
     # (
+        .clk_mhz ( clk_mhz    ),
         .w_digit ( w_tm_digit )        // fake parameter, digit count is hardcode in tm1638_board_controller
     )
     i_ledkey

--- a/boards/de10_nano_vga_mister/board_specific_top.sv
+++ b/boards/de10_nano_vga_mister/board_specific_top.sv
@@ -276,6 +276,7 @@ module board_specific_top
 
     tm1638_board_controller
     # (
+        .clk_mhz ( clk_mhz    ),
         .w_digit ( w_tm_digit )        // fake parameter, digit count is hardcode in tm1638_board_controller
     )
     i_ledkey

--- a/boards/de10_nano_vga_pmod/board_specific_top.sv
+++ b/boards/de10_nano_vga_pmod/board_specific_top.sv
@@ -265,6 +265,7 @@ module board_specific_top
 
     tm1638_board_controller
     # (
+        .clk_mhz ( clk_mhz    ),
         .w_digit ( w_tm_digit )        // fake parameter, digit count is hardcode in tm1638_board_controller
     )
     i_ledkey

--- a/boards/ice40hx8k_evb_yosys/board_specific_top.sv
+++ b/boards/ice40hx8k_evb_yosys/board_specific_top.sv
@@ -161,6 +161,7 @@ module board_specific_top
 `ifdef ENABLE_TM1638
     tm1638_board_controller
     # (
+        .clk_mhz ( clk_mhz    ),
         .w_digit ( w_tm_digit )
     )
     i_tm1638

--- a/boards/orangecrab_ecp5_yosys/board_specific_top.sv
+++ b/boards/orangecrab_ecp5_yosys/board_specific_top.sv
@@ -161,6 +161,7 @@ module board_specific_top
 `ifdef ENABLE_TM1638
     tm1638_board_controller
     # (
+        .clk_mhz ( clk_mhz ),
         .w_digit ( w_tm_digit )
     )
     i_tm1638

--- a/boards/tang_nano_20k/board_specific_top.sv
+++ b/boards/tang_nano_20k/board_specific_top.sv
@@ -151,6 +151,7 @@ module board_specific_top
 
     tm1638_board_controller
     # (
+        .clk_mhz ( clk_mhz ),
         .w_digit ( w_tm_digit )
     )
     i_tm1638

--- a/boards/tang_nano_9k/board_specific_top.sv
+++ b/boards/tang_nano_9k/board_specific_top.sv
@@ -150,6 +150,7 @@ module board_specific_top
 
     tm1638_board_controller
     # (
+        .clk_mhz ( clk_mhz ),
         .w_digit ( w_tm_digit )
     )
     i_tm1638

--- a/boards/tang_nano_9k_gowin_yosys/board_specific_top.sv
+++ b/boards/tang_nano_9k_gowin_yosys/board_specific_top.sv
@@ -157,6 +157,7 @@ module board_specific_top
 
     tm1638_board_controller
     # (
+        .clk_mhz ( clk_mhz ),
         .w_digit ( w_tm_digit )
     )
     i_tm1638

--- a/boards/tang_primer_20k_dock/board_specific_top.sv
+++ b/boards/tang_primer_20k_dock/board_specific_top.sv
@@ -156,6 +156,7 @@ module board_specific_top
 
     tm1638_board_controller
     # (
+        .clk_mhz ( clk_mhz ),
         .w_digit ( w_tm_digit )
     )
     i_tm1638

--- a/boards/tang_primer_20k_dock_alt/board_specific_top.sv
+++ b/boards/tang_primer_20k_dock_alt/board_specific_top.sv
@@ -156,6 +156,7 @@ module board_specific_top
 
     tm1638_board_controller
     # (
+        .clk_mhz ( clk_mhz ),
         .w_digit ( w_tm_digit )
     )
     i_tm1638

--- a/boards/tang_primer_20k_dock_gowin_yosys/board_specific_top.sv
+++ b/boards/tang_primer_20k_dock_gowin_yosys/board_specific_top.sv
@@ -163,6 +163,7 @@ module board_specific_top
 
     tm1638_board_controller
     # (
+        .clk_mhz ( clk_mhz ),
         .w_digit ( w_tm_digit )
     )
     i_tm1638

--- a/boards/tang_primer_20k_lite/board_specific_top.sv
+++ b/boards/tang_primer_20k_lite/board_specific_top.sv
@@ -156,6 +156,7 @@ module board_specific_top
 
     tm1638_board_controller
     # (
+        .clk_mhz ( clk_mhz ),
         .w_digit ( w_tm_digit )
     )
     i_tm1638


### PR DESCRIPTION
In many board files the tm1638_board_controller module is missing clk_mhz which causes it to produce wrong serial clock and strobe.