### PR TITLE
seven_segment_display: possible refresh rate fix

### DIFF
--- a/labs/common/seven_segment_display.sv
+++ b/labs/common/seven_segment_display.sv
@@ -4,9 +4,9 @@
 
 module seven_segment_display
 # (
-    parameter w_digit = 2,
-    parameter clk_mhz = 50,
-    parameter update_hz = 16 // How often to update display in Hz, should not be too high
+    parameter w_digit   = 2,
+    parameter clk_mhz   = 50,
+    parameter update_hz = 4 // Looks like a sane default
 )
 (
     input  clk,
@@ -15,8 +15,8 @@ module seven_segment_display
     input  [w_digit * 4 - 1:0] number,
     input  [w_digit     - 1:0] dots,
 
-    output logic [              7:0] abcdefgh,
-    output logic [w_digit     - 1:0] digit
+    output [              7:0] abcdefgh,
+    output [w_digit     - 1:0] digit
 );
 
     function [7:0] dig_to_seg (input [3:0] dig);
@@ -46,34 +46,45 @@ module seven_segment_display
 
     // Calculate display update freq divider
 
-    localparam cnt_top = clk_mhz * 1000000 / w_digit / update_hz,
-               w_cnt   = $clog2 (cnt_top);
+    localparam cnt_max = clk_mhz * 1_000_000 / update_hz,
+               w_cnt   = $clog2 (cnt_max + 1);
 
     logic [w_cnt - 1:0] cnt;
+
+
+    always_ff @ (posedge clk or posedge rst)
+        if (rst)
+            cnt <= '0;
+        else
+            cnt <= cnt + 1'd1;
+
+
+    // Update display output register with specified frequency
+
+    logic  [w_digit * 4 - 1:0] r_number;
+    wire enable = cnt == cnt_max;
+
+
+    always_ff @ (posedge clk or posedge rst)
+        if (rst)
+            r_number <= '0;
+        else if (enable)
+            r_number <= number;
+
 
     localparam w_index = $clog2 (w_digit);
     logic [w_index - 1:0] index;
 
-    // Update display digit only when necessary
 
     always_ff @ (posedge clk or posedge rst)
-        if (rst) begin
+        if (rst)
             index <= '0;
-            cnt   <= '0;
-        end else begin
-            cnt <= cnt + w_cnt' (1);
+        else if (cnt[15:0] == 16'b0) // Perhaps a check is needed that w_cnt >= 16
+            index <= (index == w_index' (w_digit - 1) ?
+                w_index' (0) : index + 1'd1);
 
-            if (cnt == cnt_top)
-            begin
-                index <= (index == w_index' (w_digit - 1) ?
-                        w_index' (0) : index + 1'd1);
-
-                if (index == { w_index { 1'b1 } })
-                    cnt <= '0;
-
-                abcdefgh <= dig_to_seg (number [index * 4 +: 4]) ^ dots [index];
-                digit    <= w_digit' (1'b1) << index;
-            end
-        end
+    // Outputs are combinational like before
+    assign abcdefgh = dig_to_seg (r_number [index * 4 +: 4]) ^ dots [index];
+    assign digit    = w_digit' (1'b1) << index;
 
 endmodule

--- a/labs/common/seven_segment_display.sv
+++ b/labs/common/seven_segment_display.sv
@@ -55,6 +55,8 @@ module seven_segment_display
     always_ff @ (posedge clk or posedge rst)
         if (rst)
             cnt <= '0;
+        else if (cnt == cnt_max)
+            cnt <= '0;
         else
             cnt <= cnt + 1'd1;
 


### PR DESCRIPTION
My attempted fix consists of code from previous versions of this file + a register to store the value of the input number.

The idea is very simple: run dynamic indication on a constant high frequency, while updating the number on a much lower frequency that can be manually specified.

Has been tested on a Saylinx board.