### PR TITLE
Refactoring pin planning for tang_nano_20k

### DIFF
--- a/boards/tang_nano_20k_hdmi_tm1638/board_specific.cst
+++ b/boards/tang_nano_20k_hdmi_tm1638/board_specific.cst
@@ -1,99 +1,154 @@
-# The pin assignments
-# All I/O pins here are 3.3V compatible unless specified otherwise
+// The pin assignments
+// All I/O pins here are 3.3V compatible unless specified otherwise
 
-IO_LOC "CLK"                4;
+    IO_LOC "CLK"                4;
 
-IO_LOC "KEY[0]"             88;
-IO_LOC "KEY[1]"             87;
+    IO_LOC "KEY[0]"             88;
+    IO_LOC "KEY[1]"             87;
 
-IO_LOC "LED[0]"             15;
-IO_LOC "LED[1]"             16;
-IO_LOC "LED[2]"             17;
-IO_LOC "LED[3]"             20;
-IO_LOC "LED[4]"             19;
-IO_LOC "LED[5]"             18;
+    IO_LOC "LED[0]"             15;
+    IO_LOC "LED[1]"             16;
+    IO_LOC "LED[2]"             17;
+    IO_LOC "LED[3]"             18;
+    IO_LOC "LED[4]"             19;
+    IO_LOC "LED[5]"             20;
+
+// Some LCD pins share bank with TMDS pins
+// which have different voltage requirements.
+// In this configuration they are commented out
+
+//  IO_LOC "LCD_CLK"            77;
+//  IO_LOC "LCD_DE"             48;
+//  IO_LOC "LCD_HS"             25;
+//  IO_LOC "LCD_VS"             26;
+
+//  IO_LOC "LCD_R[0]"           42;
+//  IO_LOC "LCD_R[1]"           41;
+//  IO_LOC "LCD_R[2]"           49;
+//  IO_LOC "LCD_R[3]"           39;
+//  IO_LOC "LCD_R[4]"           38;
+
+//  IO_LOC "LCD_G[0]"           37;
+//  IO_LOC "LCD_G[1]"           36;
+//  IO_LOC "LCD_G[2]"           35;
+//  IO_LOC "LCD_G[3]"           34;
+//  IO_LOC "LCD_G[4]"           33;
+//  IO_LOC "LCD_G[5]"           32;
+
+//  IO_LOC "LCD_B[0]"           31;
+//  IO_LOC "LCD_B[1]"           30;
+//  IO_LOC "LCD_B[2]"           29;
+//  IO_LOC "LCD_B[3]"           28;
+//  IO_LOC "LCD_B[4]"           27;
+
+// TMDS pins conflict with LCD pins
+    IO_LOC "O_TMDS_CLK_P"       33,34;
+    IO_LOC "O_TMDS_DATA_P[0]"   35,36;
+    IO_LOC "O_TMDS_DATA_P[1]"   37,38;
+    IO_LOC "O_TMDS_DATA_P[2]"   39,40;
+
+// DVI I2C
+    IO_LOC "EDID_CLK"           53;
+    IO_LOC "EDID_DAT"           52;
+
+// UART to debugger
+    IO_LOC "UART_TX"            70;
+    IO_LOC "UART_RX"            69;
+
+//  IO_LOC "UART_RXD"           31;  // Conflct with LCD_B[0]
+//  IO_LOC "UART_TXD"           30;  // Conflct with LCD_B[1]
+
+// SDIO pins for SD-cards 
+    IO_LOC "SD_CLK"             83;
+    IO_LOC "SD_CMD"             82;
+    IO_LOC "SD_DAT0"            84;
+    IO_LOC "SD_DAT1"            85;  // Used for inmp441 sck
+    IO_LOC "SD_DAT2"            80;
+    IO_LOC "SD_DAT3"            81;
+
+// Onboard I2S audio
+    IO_LOC "HP_BCK"             56;  // DAC_BCLK
+    IO_LOC "HP_DIN"             54;  // DAC_DIN
+    IO_LOC "HP_WS"              55;  // DAC_LRCK
+    IO_LOC "PA_EN"              51;  // For audio, should be assigned 1
+
+// On-board WS2812 RGB LED with a serial interface
+    IO_LOC "WS2812"             79;
+
+// GPIO for external modules
+
+//  IO_LOC "JOYSTICK_CLK"       17;  // Conflict with LED[2]
+//  IO_LOC "JOYSTICK_MOSI"      20;  // Conflict with LED[5]
+//  IO_LOC "JOYSTICK_MISO"      19;  // Conflict with LED[4]
+//  IO_LOC "JOYSTICK_CS"        18;  // Conflict with LED[3]
+
+//  IO_LOC "JOYSTICK_CLK2"      52;  // Conflicts with EDID_CLK
+//  IO_LOC "JOYSTICK_MOSI2"     53;  // Conflicts with EDID_DAT 
+    IO_LOC "JOYSTICK_MISO2"     71;  // TM1638: sio_stb
+    IO_LOC "JOYSTICK_CS2"       72;  // TM1638: sio_clk
+
+    IO_LOC "GPIO[0]"            86;  // TM1638:  sio_data
+    IO_LOC "GPIO[1]"            73;  // INMP441: i2s_lr
+    IO_LOC "GPIO[2]"            74;  // INMP441: i2s_ws
+    IO_LOC "GPIO[3]"            75;  // INMP441: i2s_sck
+//  IO_LOC "SD_DAT1"            85;  // INMP441: i2s_sd
+
+// Extra GPIO for custom tasks
+    IO_LOC "GPIO[4]"            76;  
+//  IO_LOC "SD_DAT2"            80;
+//  IO_LOC "WS2812"             79;
+//  IO_LOC "EDID_CLK"           53;
+//  IO_LOC "EDID_DAT"           52;
 
 
-# Some LCD pins share bank with TMDS pins
-# which have different voltage requirements.
-#
-# Usage of LCD conflicts with HDMI usage
+// TM1638 occupy:
+//
+// 86 GPIO[0]             - tm1638: sio_data
+// 72 JOYSTICK_CS2        - tm1638: sio_clk
+// 71 JOYSTICK_MISO2      - tm1638: sio_stb
 
-# IO_LOC "LCD_DE"           48;
-# IO_LOC "LCD_VS"           26;
-# IO_LOC "LCD_HS"           25;
-# IO_LOC "LCD_CLK"          77;
-# IO_LOC "LCD_INIT"         76;
-# IO_LOC "LCD_BL"           49;
+// INMP 441 occupy:
+//
+// 73 GPIO[1]             - inmp441: lr
+// 74 GPIO[2]             - inmp441: ws
+// 75 GPIO[3]             - inmp441: sck
+// 85 SD_DAT1             - inmp441: sd
 
-# IO_LOC "LCD_R[3]"         42;
-# IO_LOC "LCD_R[4]"         41;
-# IO_LOC "LCD_R[5]"         49;
-# IO_LOC "LCD_R[6]"         39;
-# IO_LOC "LCD_R[7]"         38;
+// Extra pins for GPIO:
+//
+// 76 GCLKC_1             - gpio[0]
+// 80 SD_DAT2             - gpio[1]
+// Consider 79 / 2812_DIN
+// Consider 53 / EDID_CLK
+// Consider 52 / EDID_DAT
 
-# IO_LOC "LCD_G[2]"         37;
-# IO_LOC "LCD_G[3]"         36;
-# IO_LOC "LCD_G[4]"         35;
-# IO_LOC "LCD_G[5]"         34;
-# IO_LOC "LCD_G[6]"         33;
-# IO_LOC "LCD_G[7]"         32;
-
-# IO_LOC "LCD_B[3]"         31;
-# IO_LOC "LCD_B[4]"         30;
-# IO_LOC "LCD_B[5]"         29;
-# IO_LOC "LCD_B[6]"         28;
-# IO_LOC "LCD_B[7]"         27;
-
-# UART to debugger
-IO_LOC "UART_TX"            70;
-IO_LOC "UART_RX"            69;
-
-# The following 4 pins (MIC_LR, MIC_WS, MIC_SCLK, MIC_SD)
-# are used for INMP441 microphone
-# in basics-graphics-music labs
-
-IO_LOC "MIC_LR"             72;
-IO_LOC "MIC_WS"             71;
-IO_LOC "MIC_SCLK"           53;
-IO_LOC "MIC_SD"             52;
-
-# The first 3 GPIO pins are used for TM1638 I/O module
-# which carries 8 LEDs, 8-digit 7-segment display and 8 keys
-
-# Config for usage with maket board (do not use board power pins)  
-IO_LOC "GPIO[0]"            73;  # tm1638: sio_data
-IO_LOC "GPIO[1]"            74;  # tm1638: sio_clk
-IO_LOC "GPIO[2]"            75;  # tm1638: sio_stb
-
-# Alternative config without maket board (use board power pins)
-# conflicts with usage of LED[5:3]
-# IO_LOC "GPIO[0]"          20;  # tm1638: sio_data
-# IO_LOC "GPIO[1]"          19;  # tm1638: sio_clk
-# IO_LOC "GPIO[2]"          18;  # tm1638: sio_stb
-
-IO_LOC "GPIO[3]"            86;
-IO_LOC "GPIO[4]"            79;
-
-# TMDS pins for HDMI output
-IO_LOC "TMDS_CLK_P"         34,33;
-IO_LOC "TMDS_D_P[0]"        36,35;
-IO_LOC "TMDS_D_P[1]"        38,37;
-IO_LOC "TMDS_D_P[2]"        40,39;
-
-# SDIO pins for SD-cards 
-# IO_LOC "SDIO_D1"          85;
-# IO_LOC "SDIO_D0"          84;
-# IO_LOC "SDIO_CLK"         83;
-# IO_LOC "SDIO_CMD"         82;
-# IO_LOC "SDIO_D3"          81;
-# IO_LOC "SDIO_D2"          80;
-
-# Onboard I2S audio
-IO_LOC "I2S_BCLK"           56;
-IO_LOC "I2S_LRCK"           55;
-IO_LOC "I2S_DIN"            54;
-IO_LOC "I2S_EN"             51;
-
-# WS2812, conflicts with GPIO[5]
-# IO_LOC "WS2812"           79;
+// Pin conflicts:
+//
+// 17;        IO_LOC "JOYSTICK_CLK"
+// 17;        IO_LOC "LED[2]"     
+//
+// 18;        IO_LOC "JOYSTICK_CS"
+// 18;        IO_LOC "LED[3]"      
+// 
+// 19;        IO_LOC "JOYSTICK_MISO"
+// 19;        IO_LOC "LED[4]"
+// 
+// 20;        IO_LOC "JOYSTICK_MOSI"
+// 20;        IO_LOC "LED[5]"
+// 
+// 30;        IO_LOC "LCD_B[1]"
+// 30;        IO_LOC "UART_TXD"
+//
+// 31;        IO_LOC "LCD_B[0]"
+// 31;        IO_LOC "UART_RXD"
+//
+// 33,34;     IO_LOC "O_TMDS_CLK_P"
+// 33;        IO_LOC "LCD_G[4]"
+// 
+// 35,36;     IO_LOC "O_TMDS_DATA_P[0]"
+// 35;        IO_LOC "LCD_G[2]"
+//
+// 37,38;     IO_LOC "O_TMDS_DATA_P[1]"
+// 37;        IO_LOC "LCD_G[0]"
+//
+// 39,40;     IO_LOC "O_TMDS_DATA_P[2]"

--- a/boards/tang_nano_20k_hdmi_tm1638/board_specific_top.sv
+++ b/boards/tang_nano_20k_hdmi_tm1638/board_specific_top.sv
@@ -16,7 +16,7 @@ module board_specific_top
     parameter clk_mhz       = 27,
               pixel_mhz     = 25,
 
-              w_key         = 2,  // The last key is used for a reset
+              w_key         = 2,
               w_sw          = 0,
               w_led         = 6,
               w_digit       = 0,
@@ -25,9 +25,9 @@ module board_specific_top
               screen_width  = 800,
               screen_height = 480,
 
-              w_red         = 8,
-              w_green       = 8,
-              w_blue        = 8,
+              w_red         = 5,
+              w_green       = 6,
+              w_blue        = 5,
 
               w_x           = $clog2 ( screen_width  ),
               w_y           = $clog2 ( screen_height )
@@ -46,8 +46,6 @@ module board_specific_top
     // output                    LCD_VS,
     // output                    LCD_HS,
     // output                    LCD_CLK,
-    // output                    LCD_BL,
-    // output                    LCD_INIT,
 
     // output [            4:0]  LCD_R,
     // output [            5:0]  LCD_G,
@@ -56,27 +54,43 @@ module board_specific_top
     input                        UART_RX,
     output                       UART_TX,
 
-    // The following 4 pins (MIC_LR, MIC_WS, MIC_SCLK, MIC_SD)
-    // are used for INMP441 microphone
-    // in basics-graphics-music labs
-
-    inout                        MIC_LR,
-    inout                        MIC_WS,
-    inout                        MIC_SCLK,
-    inout                        MIC_SD,
-
     inout  [w_gpio       - 1:0]  GPIO,
 
-    output                       TMDS_CLK_N,
-    output                       TMDS_CLK_P,
-    output [               2:0]  TMDS_D_N,
-    output [               2:0]  TMDS_D_P,
+    // DVI ports
+    output                       O_TMDS_CLK_N,
+    output                       O_TMDS_CLK_P,
+    output [               2:0]  O_TMDS_DATA_N,
+    output [               2:0]  O_TMDS_DATA_P,
 
-    // Pins for onboard I2S DAC
-    output                       I2S_BCLK,
-    output                       I2S_LRCK,
-    output                       I2S_DIN,
-    output                       I2S_EN
+    inout                        EDID_CLK,
+    inout                        EDID_DAT,
+
+    // output                    JOYSTICK_CLK,
+    // output                    JOYSTICK_MOSI,
+    // output                    JOYSTICK_MISO,
+    // output                    JOYSTICK_CS,
+
+    // output                    JOYSTICK_CLK2,
+    // output                    JOYSTICK_MOSI2,
+    output                       JOYSTICK_MISO2,
+    output                       JOYSTICK_CS2,
+
+    // SD card ports
+    output                       SD_CLK,
+    output                       SD_CMD,
+    inout                        SD_DAT0,
+    inout                        SD_DAT1,
+    inout                        SD_DAT2,
+    inout                        SD_DAT3, 
+
+    // Ports for on-board I2S amplifier
+    output                       HP_BCK,
+    output                       HP_DIN,
+    output                       HP_WS,
+    output                       PA_EN,
+
+    // On-board WS2812 RGB LED with a serial interface
+    inout                        WS2812
 );
 
     wire clk = CLK;
@@ -248,8 +262,8 @@ module board_specific_top
         .ledr     ( tm_led         ),
         .keys     ( tm_key         ),
         .sio_data ( GPIO [0]       ),
-        .sio_clk  ( GPIO [1]       ),
-        .sio_stb  ( GPIO [2]       )
+        .sio_clk  ( JOYSTICK_CS2   ),
+        .sio_stb  ( JOYSTICK_MISO2 )
     );
 
     `endif
@@ -300,19 +314,19 @@ module board_specific_top
 
         DVI_TX_Top i_DVI_TX_Top
         (
-            .I_rst_n       ( ~ rst         ),
-            .I_serial_clk  (   serial_clk  ),
-            .I_rgb_clk     (   pixel_clk   ),
-            .I_rgb_vs      ( ~ vsync       ),
-            .I_rgb_hs      ( ~ hsync       ),
-            .I_rgb_de      (   display_on  ),
-            .I_rgb_r       (   red         ),
-            .I_rgb_g       (   green       ),
-            .I_rgb_b       (   blue        ),
-            .O_tmds_clk_p  (   TMDS_CLK_P  ),
-            .O_tmds_clk_n  (   TMDS_CLK_N  ),
-            .O_tmds_data_p (   TMDS_D_P    ),
-            .O_tmds_data_n (   TMDS_D_N    )
+            .I_rst_n       ( ~ rst           ),
+            .I_serial_clk  (   serial_clk    ),
+            .I_rgb_clk     (   pixel_clk     ),
+            .I_rgb_vs      ( ~ vsync         ),
+            .I_rgb_hs      ( ~ hsync         ),
+            .I_rgb_de      (   display_on    ),
+            .I_rgb_r       (   red           ),
+            .I_rgb_g       (   green         ),
+            .I_rgb_b       (   blue          ),
+            .O_tmds_clk_p  (   O_TMDS_CLK_P  ),
+            .O_tmds_clk_n  (   O_TMDS_CLK_N  ),
+            .O_tmds_data_p (   O_TMDS_DATA_P ),
+            .O_tmds_data_n (   O_TMDS_DATA_N )
         );
 
     `endif
@@ -329,10 +343,10 @@ module board_specific_top
         (
             .clk      ( clk            ),
             .rst      ( rst            ),
-            .lr       ( MIC_LR         ),
-            .ws       ( MIC_WS         ),
-            .sck      ( MIC_SCLK       ),
-            .sd       ( MIC_SD         ),
+            .lr       ( GPIO[1]        ),
+            .ws       ( GPIO[2]        ),
+            .sck      ( GPIO[3]        ),
+            .sd       ( SD_DAT1        ),
             .value    ( mic            )
         );
 
@@ -343,7 +357,7 @@ module board_specific_top
     `ifdef INSTANTIATE_SOUND_OUTPUT_INTERFACE_MODULE
 
         // For tang_nano_20k DAC do not require mclk signal
-        // but it needs enable signal I2S_EN
+        // but it needs enable signal PA_EN
 
         i2s_audio_out
         # (
@@ -355,13 +369,13 @@ module board_specific_top
             .reset    ( rst          ),
             .data_in  ( sound        ),
             .mclk     (              ),
-            .bclk     ( I2S_BCLK     ),
-            .lrclk    ( I2S_LRCK     ),
-            .sdata    ( I2S_DIN      )
+            .bclk     ( HP_BCK       ),
+            .lrclk    ( HP_WS        ),
+            .sdata    ( HP_DIN       )
         );
 
         // Enable DAC
-        assign I2S_EN = 1'b1;
+        assign PA_EN = 1'b1;
 
     `endif
 

--- a/boards/tang_nano_20k_lcd_800_480_tm1638/board_specific.cst
+++ b/boards/tang_nano_20k_lcd_800_480_tm1638/board_specific.cst
@@ -1,99 +1,154 @@
-# The pin assignments
-# All I/O pins here are 3.3V compatible unless specified otherwise
+// The pin assignments
+// All I/O pins here are 3.3V compatible unless specified otherwise
 
-IO_LOC "CLK"                4;
+    IO_LOC "CLK"                4;
 
-IO_LOC "KEY[0]"             88;
-IO_LOC "KEY[1]"             87;
+    IO_LOC "KEY[0]"             88;
+    IO_LOC "KEY[1]"             87;
 
-IO_LOC "LED[0]"             15;
-IO_LOC "LED[1]"             16;
-IO_LOC "LED[2]"             17;
-IO_LOC "LED[3]"             20;
-IO_LOC "LED[4]"             19;
-IO_LOC "LED[5]"             18;
+    IO_LOC "LED[0]"             15;
+    IO_LOC "LED[1]"             16;
+    IO_LOC "LED[2]"             17;
+    IO_LOC "LED[3]"             18;
+    IO_LOC "LED[4]"             19;
+    IO_LOC "LED[5]"             20;
+
+// Some LCD pins share bank with TMDS pins
+// which have different voltage requirements.
+
+    IO_LOC "LCD_CLK"            77;
+    IO_LOC "LCD_DE"             48;
+    IO_LOC "LCD_HS"             25;
+    IO_LOC "LCD_VS"             26;
+
+    IO_LOC "LCD_R[0]"           42;
+    IO_LOC "LCD_R[1]"           41;
+    IO_LOC "LCD_R[2]"           49;
+    IO_LOC "LCD_R[3]"           39;
+    IO_LOC "LCD_R[4]"           38;
+
+    IO_LOC "LCD_G[0]"           37;
+    IO_LOC "LCD_G[1]"           36;
+    IO_LOC "LCD_G[2]"           35;
+    IO_LOC "LCD_G[3]"           34;
+    IO_LOC "LCD_G[4]"           33;
+    IO_LOC "LCD_G[5]"           32;
+
+    IO_LOC "LCD_B[0]"           31;
+    IO_LOC "LCD_B[1]"           30;
+    IO_LOC "LCD_B[2]"           29;
+    IO_LOC "LCD_B[3]"           28;
+    IO_LOC "LCD_B[4]"           27;
+
+// TMDS pins conflict with LCD pins
+// In this configuration they are commented out
+//  IO_LOC "O_TMDS_CLK_P"       33,34;
+//  IO_LOC "O_TMDS_DATA_P[0]"   35,36;
+//  IO_LOC "O_TMDS_DATA_P[1]"   37,38;
+//  IO_LOC "O_TMDS_DATA_P[2]"   39,40;
+
+// DVI I2C
+    IO_LOC "EDID_CLK"           53;
+    IO_LOC "EDID_DAT"           52;
+
+// UART to debugger
+    IO_LOC "UART_TX"            70;
+    IO_LOC "UART_RX"            69;
+
+//  IO_LOC "UART_RXD"           31;  // Conflct with LCD_B[0]
+//  IO_LOC "UART_TXD"           30;  // Conflct with LCD_B[1]
+
+// SDIO pins for SD-cards 
+    IO_LOC "SD_CLK"             83;
+    IO_LOC "SD_CMD"             82;
+    IO_LOC "SD_DAT0"            84;
+    IO_LOC "SD_DAT1"            85;  // Used for inmp441 sck
+    IO_LOC "SD_DAT2"            80;
+    IO_LOC "SD_DAT3"            81;
+
+// Onboard I2S audio
+    IO_LOC "HP_BCK"             56;  // DAC_BCLK
+    IO_LOC "HP_DIN"             54;  // DAC_DIN
+    IO_LOC "HP_WS"              55;  // DAC_LRCK
+    IO_LOC "PA_EN"              51;  // For audio, should be assigned 1
+
+// On-board WS2812 RGB LED with a serial interface
+    IO_LOC "WS2812"             79;
+
+// GPIO for external modules
+
+//  IO_LOC "JOYSTICK_CLK"       17;  // Conflict with LED[2]
+//  IO_LOC "JOYSTICK_MOSI"      20;  // Conflict with LED[5]
+//  IO_LOC "JOYSTICK_MISO"      19;  // Conflict with LED[4]
+//  IO_LOC "JOYSTICK_CS"        18;  // Conflict with LED[3]
+
+//  IO_LOC "JOYSTICK_CLK2"      52;  // Conflicts with EDID_CLK
+//  IO_LOC "JOYSTICK_MOSI2"     53;  // Conflicts with EDID_DAT 
+    IO_LOC "JOYSTICK_MISO2"     71;  // TM1638: sio_stb
+    IO_LOC "JOYSTICK_CS2"       72;  // TM1638: sio_clk
+
+    IO_LOC "GPIO[0]"            86;  // TM1638:  sio_data
+    IO_LOC "GPIO[1]"            73;  // INMP441: i2s_lr
+    IO_LOC "GPIO[2]"            74;  // INMP441: i2s_ws
+    IO_LOC "GPIO[3]"            75;  // INMP441: i2s_sck
+//  IO_LOC "SD_DAT1"            85;  // INMP441: i2s_sd
+
+// Extra GPIO for custom tasks
+    IO_LOC "GPIO[4]"            76;  
+//  IO_LOC "SD_DAT2"            80;
+//  IO_LOC "WS2812"             79;
+//  IO_LOC "EDID_CLK"           53;
+//  IO_LOC "EDID_DAT"           52;
 
 
-# Some LCD pins share bank with TMDS pins
-# which have different voltage requirements.
-#
-# Usage of LCD conflicts with HDMI usage
+// TM1638 occupy:
+//
+// 86 GPIO[0]             - tm1638: sio_data
+// 72 JOYSTICK_CS2        - tm1638: sio_clk
+// 71 JOYSTICK_MISO2      - tm1638: sio_stb
 
-IO_LOC "LCD_DE"             48;
-IO_LOC "LCD_VS"             26;
-IO_LOC "LCD_HS"             25;
-IO_LOC "LCD_CK"             77;
-IO_LOC "LCD_INIT"           76;
-IO_LOC "LCD_BL"             49;
+// INMP 441 occupy:
+//
+// 73 GPIO[1]             - inmp441: lr
+// 74 GPIO[2]             - inmp441: ws
+// 75 GPIO[3]             - inmp441: sck
+// 85 SD_DAT1             - inmp441: sd
 
-IO_LOC "LCD_R[3]"           42;
-IO_LOC "LCD_R[4]"           41;
-IO_LOC "LCD_R[5]"           40;
-IO_LOC "LCD_R[6]"           39;
-IO_LOC "LCD_R[7]"           38;
+// Extra pins for GPIO:
+//
+// 76 GCLKC_1             - gpio[0]
+// 80 SD_DAT2             - gpio[1]
+// Consider 79 / 2812_DIN
+// Consider 53 / EDID_CLK
+// Consider 52 / EDID_DAT
 
-IO_LOC "LCD_G[2]"           37;
-IO_LOC "LCD_G[3]"           36;
-IO_LOC "LCD_G[4]"           35;
-IO_LOC "LCD_G[5]"           34;
-IO_LOC "LCD_G[6]"           33;
-IO_LOC "LCD_G[7]"           32;
-
-IO_LOC "LCD_B[3]"           31;
-IO_LOC "LCD_B[4]"           30;
-IO_LOC "LCD_B[5]"           29;
-IO_LOC "LCD_B[6]"           28;
-IO_LOC "LCD_B[7]"           27;
-
-# UART to debugger
-IO_LOC "UART_TX"            70;
-IO_LOC "UART_RX"            69;
-
-# The following 4 pins (MIC_LR, MIC_WS, MIC_SCLK, MIC_SD)
-# are used for INMP441 microphone
-# in basics-graphics-music labs
-
-IO_LOC "MIC_LR"             72;
-IO_LOC "MIC_WS"             71;
-IO_LOC "MIC_SCLK"           53;
-IO_LOC "MIC_SD"             52;
-
-# The first 3 GPIO pins are used for TM1638 I/O module
-# which carries 8 LEDs, 8-digit 7-segment display and 8 keys
-
-# Config for usage with maket board (do not use board power pins)  
-IO_LOC "GPIO[0]"            73;  # tm1638: sio_data
-IO_LOC "GPIO[1]"            74;  # tm1638: sio_clk
-IO_LOC "GPIO[2]"            75;  # tm1638: sio_stb
-
-# Alternative config without maket board (use board power pins)
-# conflicts with usage of LED[5:3]
-# IO_LOC "GPIO[0]"          20;  # tm1638: sio_data
-# IO_LOC "GPIO[1]"          19;  # tm1638: sio_clk
-# IO_LOC "GPIO[2]"          18;  # tm1638: sio_stb
-
-IO_LOC "GPIO[3]"            86;
-IO_LOC "GPIO[4]"            79;
-
-# TMDS pins for HDMI output
-# IO_LOC "TMDS_CLK_P"       34,33;
-# IO_LOC "TMDS_D_P[0]"      36,35;
-# IO_LOC "TMDS_D_P[1]"      38,37;
-# IO_LOC "TMDS_D_P[2]"      40,39;
-
-# SDIO pins for SD-cards 
-# IO_LOC "SDIO_D1"          85;
-# IO_LOC "SDIO_D0"          84;
-# IO_LOC "SDIO_CLK"         83;
-# IO_LOC "SDIO_CMD"         82;
-# IO_LOC "SDIO_D3"          81;
-# IO_LOC "SDIO_D2"          80;
-
-# Onboard I2S audio
-IO_LOC "I2S_BCLK"           56;
-IO_LOC "I2S_LRCK"           55;
-IO_LOC "I2S_DIN"            54;
-IO_LOC "I2S_EN"             51;
-
-# WS2812, conflicts with GPIO[4]
-# IO_LOC "WS2812"           79;
+// Pin conflicts:
+//
+// 17;        IO_LOC "JOYSTICK_CLK"
+// 17;        IO_LOC "LED[2]"     
+//
+// 18;        IO_LOC "JOYSTICK_CS"
+// 18;        IO_LOC "LED[3]"      
+// 
+// 19;        IO_LOC "JOYSTICK_MISO"
+// 19;        IO_LOC "LED[4]"
+// 
+// 20;        IO_LOC "JOYSTICK_MOSI"
+// 20;        IO_LOC "LED[5]"
+// 
+// 30;        IO_LOC "LCD_B[1]"
+// 30;        IO_LOC "UART_TXD"
+//
+// 31;        IO_LOC "LCD_B[0]"
+// 31;        IO_LOC "UART_RXD"
+//
+// 33,34;     IO_LOC "O_TMDS_CLK_P"
+// 33;        IO_LOC "LCD_G[4]"
+// 
+// 35,36;     IO_LOC "O_TMDS_DATA_P[0]"
+// 35;        IO_LOC "LCD_G[2]"
+//
+// 37,38;     IO_LOC "O_TMDS_DATA_P[1]"
+// 37;        IO_LOC "LCD_G[0]"
+//
+// 39,40;     IO_LOC "O_TMDS_DATA_P[2]"

--- a/boards/tang_nano_20k_lcd_800_480_tm1638/board_specific.sdc
+++ b/boards/tang_nano_20k_lcd_800_480_tm1638/board_specific.sdc
@@ -2,4 +2,4 @@
 //
 
 create_clock -name CLK    -period 37.037 -waveform {0 18.518} [get_ports {CLK}]
-create_clock -name LCD_CK -period 111.11 -waveform {0 55.555} [get_ports {LCD_CK}]
+create_clock -name LCD_CLK -period 111.11 -waveform {0 55.555} [get_ports {LCD_CLK}]

--- a/boards/tang_nano_20k_lcd_800_480_tm1638/board_specific_top.sv
+++ b/boards/tang_nano_20k_lcd_800_480_tm1638/board_specific_top.sv
@@ -48,40 +48,52 @@ module board_specific_top
     output                       LCD_DE,
     output                       LCD_VS,
     output                       LCD_HS,
-    output                       LCD_CK,
-    output                       LCD_BL,
-    output                       LCD_INIT,
+    output                       LCD_CLK,
 
-    output [7:7 + 1 - w_red   ]  LCD_R,
-    output [7:7 + 1 - w_green ]  LCD_G,
-    output [7:7 + 1 - w_blue  ]  LCD_B,
+    output [            4:0]     LCD_R,
+    output [            5:0]     LCD_G,
+    output [            4:0]     LCD_B,
 
     input                        UART_RX,
     output                       UART_TX,
 
-    // The following 4 pins (MIC_LR, MIC_WS, MIC_SCLK, MIC_SD)
-    // are used for INMP441 microphone
-    // in basics-graphics-music labs
-
-    inout                        MIC_LR,
-    inout                        MIC_WS,
-    inout                        MIC_SCLK,
-    inout                        MIC_SD,
-
     inout  [w_gpio       - 1:0]  GPIO,
 
-    // TMDS pins conflict with LCD pins
+    // DVI ports
+    // output                    O_TMDS_CLK_N,
+    // output                    O_TMDS_CLK_P,
+    // output [            2:0]  O_TMDS_DATA_N,
+    // output [            2:0]  O_TMDS_DATA_P,
 
-    // output                       TMDS_CLK_N,
-    // output                       TMDS_CLK_P,
-    // output [               2:0]  TMDS_D_N,
-    // output [               2:0]  TMDS_D_P,
+    inout                        EDID_CLK,
+    inout                        EDID_DAT,
 
-    // Pins for onboard I2S DAC
-    output                       I2S_BCLK,
-    output                       I2S_LRCK,
-    output                       I2S_DIN,
-    output                       I2S_EN
+    // output                    JOYSTICK_CLK,
+    // output                    JOYSTICK_MOSI,
+    // output                    JOYSTICK_MISO,
+    // output                    JOYSTICK_CS,
+
+    // output                    JOYSTICK_CLK2,
+    // output                    JOYSTICK_MOSI2,
+    output                       JOYSTICK_MISO2,
+    output                       JOYSTICK_CS2,
+
+    // SD card ports
+    output                       SD_CLK,
+    output                       SD_CMD,
+    inout                        SD_DAT0,
+    inout                        SD_DAT1,
+    inout                        SD_DAT2,
+    inout                        SD_DAT3, 
+
+    // Ports for on-board I2S amplifier
+    output                       HP_BCK,
+    output                       HP_DIN,
+    output                       HP_WS,
+    output                       PA_EN,
+
+    // On-board WS2812 RGB LED with a serial interface
+    inout                        WS2812
 );
 
     wire clk = CLK;
@@ -258,8 +270,8 @@ module board_specific_top
         .ledr     ( tm_led         ),
         .keys     ( tm_key         ),
         .sio_data ( GPIO [0]       ),
-        .sio_clk  ( GPIO [1]       ),
-        .sio_stb  ( GPIO [2]       )
+        .sio_clk  ( JOYSTICK_CS2   ),
+        .sio_stb  ( JOYSTICK_MISO2 )
     );
 
     `endif
@@ -310,10 +322,10 @@ module board_specific_top
         (
             .clk      ( clk            ),
             .rst      ( rst            ),
-            .lr       ( MIC_LR         ),
-            .ws       ( MIC_WS         ),
-            .sck      ( MIC_SCLK       ),
-            .sd       ( MIC_SD         ),
+            .lr       ( GPIO[1]        ),
+            .ws       ( GPIO[2]        ),
+            .sck      ( GPIO[3]        ),
+            .sd       ( SD_DAT1        ),
             .value    ( mic            )
         );
 
@@ -324,7 +336,7 @@ module board_specific_top
     `ifdef INSTANTIATE_SOUND_OUTPUT_INTERFACE_MODULE
 
         // For tang_nano_20k DAC do not require mclk signal
-        // but it needs enable signal I2S_EN
+        // but it needs enable signal PA_EN
 
         i2s_audio_out
         # (
@@ -336,13 +348,13 @@ module board_specific_top
             .reset    ( rst          ),
             .data_in  ( sound        ),
             .mclk     (              ),
-            .bclk     ( I2S_BCLK     ),
-            .lrclk    ( I2S_LRCK     ),
-            .sdata    ( I2S_DIN      )
+            .bclk     ( HP_BCK       ),
+            .lrclk    ( HP_WS        ),
+            .sdata    ( HP_DIN       )
         );
 
         // Enable DAC
-        assign I2S_EN = 1'b1;
+        assign PA_EN = 1'b1;
 
     `endif
 


### PR DESCRIPTION
Revised the port names according to the feedback.

Current configurations tang_nano_20k_hdmi_tm1638 and tang_nano_20k_lcd_800_480_tm1638 
are passing synthesis.

It is required to test the new version.

---

Переработал нименования портов в соответсвиие с замечаниями.

Текущие конфигурации tang_nano_20k_hdmi_tm1638 и tang_nano_20k_lcd_800_480_tm1638 
проходят синтез.

Требуется протестировать новую версию.