### PR TITLE
Fix frequency for inmp441

### DIFF
--- a/boards/tang_nano_9k_hdmi_tm1638/board_specific_top.sv
+++ b/boards/tang_nano_9k_hdmi_tm1638/board_specific_top.sv
@@ -387,7 +387,7 @@ module board_specific_top
         wire inmp441_slow_clk;
 
         slow_clk_gen # (.fast_clk_mhz (serial_clk_mhz), .slow_clk_hz (50))
-        inpm441_slow_clk_gen (.slow_clk (inmp441_slow_clk), .*);
+        inpm441_slow_clk_gen (.clk(serial_clk), .rst(rst), .slow_clk (inmp441_slow_clk));
 
         inmp441_mic_i2s_receiver
         # (

--- a/boards/tang_nano_9k_hdmi_tm1638/board_specific_top.sv
+++ b/boards/tang_nano_9k_hdmi_tm1638/board_specific_top.sv
@@ -230,22 +230,6 @@ module board_specific_top
 
     //------------------------------------------------------------------------
 
-    localparam serial_clk_mhz = 125;
-
-    wire serial_clk;
-
-    Gowin_rPLL i_Gowin_rPLL
-    (
-        .clkin  ( clk        ),
-        .clkout ( serial_clk ),
-        .lock   (            )
-    );
-
-    // Do we need to put serial_clk through BUFG?
-    // BUFG i_BUFG (.I (raw_serial_clk), .O (serial_clk));
-
-    //------------------------------------------------------------------------
-
     lab_top
     # (
         .clk_mhz       ( clk_mhz       ),
@@ -313,29 +297,45 @@ module board_specific_top
 
     `ifdef INSTANTIATE_TM1638_BOARD_CONTROLLER_MODULE
 
-    tm1638_board_controller
-    # (
-        .clk_mhz  ( clk_mhz        ),
-        .w_digit  ( w_tm_digit     )
-    )
-    i_tm1638
-    (
-        .clk      ( clk            ),
-        .rst      ( rst            ),
-        .hgfedcba ( hgfedcba       ),
-        .digit    ( tm_digit       ),
-        .ledr     ( tm_led         ),
-        .keys     ( tm_key         ),
-        .sio_data ( GPIO [0]       ),
-        .sio_clk  ( GPIO [1]       ),
-        .sio_stb  ( GPIO [2]       )
-    );
+        tm1638_board_controller
+        # (
+            .clk_mhz  ( clk_mhz        ),
+            .w_digit  ( w_tm_digit     )
+        )
+        i_tm1638
+        (
+            .clk      ( clk            ),
+            .rst      ( rst            ),
+            .hgfedcba ( hgfedcba       ),
+            .digit    ( tm_digit       ),
+            .ledr     ( tm_led         ),
+            .keys     ( tm_key         ),
+            .sio_data ( GPIO [0]       ),
+            .sio_clk  ( GPIO [1]       ),
+            .sio_stb  ( GPIO [2]       )
+        );
 
     `endif
 
     //------------------------------------------------------------------------
 
     `ifdef INSTANTIATE_GRAPHICS_INTERFACE_MODULE
+
+        localparam serial_clk_mhz = 125;
+
+        wire serial_clk;
+
+        Gowin_rPLL i_Gowin_rPLL
+        (
+            .clkin  ( clk        ),
+            .clkout ( serial_clk ),
+            .lock   (            )
+        );
+
+        // Do we need to put serial_clk through BUFG?
+        // BUFG i_BUFG (.I (raw_serial_clk), .O (serial_clk));
+
+        //--------------------------------------------------------------------
 
         wire hsync, vsync, display_on, pixel_clk;
 
@@ -384,24 +384,19 @@ module board_specific_top
 
     `ifdef INSTANTIATE_MICROPHONE_INTERFACE_MODULE
 
-        wire inmp441_slow_clk;
-
-        slow_clk_gen # (.fast_clk_mhz (serial_clk_mhz), .slow_clk_hz (50))
-        inpm441_slow_clk_gen (.clk(serial_clk), .rst(rst), .slow_clk (inmp441_slow_clk));
-
         inmp441_mic_i2s_receiver
         # (
-            .clk_mhz  ( 50                  )
+            .clk_mhz  ( clk_mhz        )
         )
         i_microphone
         (
-            .clk      ( inmp441_slow_clk    ),
-            .rst      ( rst                 ),
-            .lr       ( TF_CS               ),
-            .ws       ( TF_MOSI             ),
-            .sck      ( TF_SCLK             ),
-            .sd       ( TF_MISO             ),
-            .value    ( mic                 )
+            .clk      ( clk            ),
+            .rst      ( rst            ),
+            .lr       ( TF_CS          ),
+            .ws       ( TF_MOSI        ),
+            .sck      ( TF_SCLK        ),
+            .sd       ( TF_MISO        ),
+            .value    ( mic            )
         );
 
     `endif

--- a/boards/tang_nano_9k_hdmi_tm1638/board_specific_top.sv
+++ b/boards/tang_nano_9k_hdmi_tm1638/board_specific_top.sv
@@ -230,6 +230,22 @@ module board_specific_top
 
     //------------------------------------------------------------------------
 
+    localparam serial_clk_mhz = 125;
+
+    wire serial_clk;
+
+    Gowin_rPLL i_Gowin_rPLL
+    (
+        .clkin  ( clk        ),
+        .clkout ( serial_clk ),
+        .lock   (            )
+    );
+
+    // Do we need to put serial_clk through BUFG?
+    // BUFG i_BUFG (.I (raw_serial_clk), .O (serial_clk));
+
+    //------------------------------------------------------------------------
+
     lab_top
     # (
         .clk_mhz       ( clk_mhz       ),
@@ -321,22 +337,6 @@ module board_specific_top
 
     `ifdef INSTANTIATE_GRAPHICS_INTERFACE_MODULE
 
-        localparam serial_clk_mhz = 125;
-
-        wire serial_clk;
-
-        Gowin_rPLL i_Gowin_rPLL
-        (
-            .clkin  ( clk        ),
-            .clkout ( serial_clk ),
-            .lock   (            )
-        );
-
-        // Do we need to put serial_clk through BUFG?
-        // BUFG i_BUFG (.I (raw_serial_clk), .O (serial_clk));
-
-        //--------------------------------------------------------------------
-
         wire hsync, vsync, display_on, pixel_clk;
 
         wire [9:0] x10; assign x = x10;
@@ -384,19 +384,24 @@ module board_specific_top
 
     `ifdef INSTANTIATE_MICROPHONE_INTERFACE_MODULE
 
+        wire inmp441_slow_clk;
+
+        slow_clk_gen # (.fast_clk_mhz (serial_clk_mhz), .slow_clk_hz (50))
+        inpm441_slow_clk_gen (.slow_clk (inmp441_slow_clk), .*);
+
         inmp441_mic_i2s_receiver
         # (
-            .clk_mhz  ( clk_mhz        )
+            .clk_mhz  ( 50                  )
         )
         i_microphone
         (
-            .clk      ( clk            ),
-            .rst      ( rst            ),
-            .lr       ( TF_CS          ),
-            .ws       ( TF_MOSI        ),
-            .sck      ( TF_SCLK        ),
-            .sd       ( TF_MISO        ),
-            .value    ( mic            )
+            .clk      ( inmp441_slow_clk    ),
+            .rst      ( rst                 ),
+            .lr       ( TF_CS               ),
+            .ws       ( TF_MOSI             ),
+            .sck      ( TF_SCLK             ),
+            .sd       ( TF_MISO             ),
+            .value    ( mic                 )
         );
 
     `endif

--- a/peripherals/inmp441_mic_i2s_receiver.sv
+++ b/peripherals/inmp441_mic_i2s_receiver.sv
@@ -20,21 +20,49 @@ module inmp441_mic_i2s_receiver
 
     //------------------------------------------------------------------------
 
+    parameter int BASE_CLK_MHZ = 50;
+
     logic clk_en;
 
     generate
-        if (clk_mhz == 100)
-        begin : clk_100
+        if (clk_mhz > BASE_CLK_MHZ) 
+        begin : g_cnt_enable
+            
+            localparam int clk_ratio = (clk_mhz * 1000 * 1000) / (BASE_CLK_MHZ * 1000 * 1000);
+            localparam int w_cnt = $clog2 (clk_ratio);
+
+            logic [w_cnt - 1:0] cnt;
+
             always_ff @ (posedge clk or posedge rst)
+            begin
                 if (rst)
-                    clk_en <= '0;
+                begin
+                    cnt     <= '0;
+                    clk_en  <= '0;
+                end
+                else if (cnt == '0)
+                begin
+                    cnt     <= w_cnt' (clk_ratio - 1);
+                    clk_en  <= '1;
+                end
                 else
-                    clk_en <= ~ clk_en;
+                begin
+                    cnt     <= cnt - 1'd1;
+                    clk_en  <= '0;
+                end
+            end
+
         end
-        else
-        begin : not_clk_100
+        else if (clk_mhz == BASE_CLK_MHZ)
+        begin : g_full_enable
             assign clk_en = '1;
         end
+        else
+        begin : g_enable_is_not_possible
+            $fatal("Generation of clk_enable is not possible for given frequency. Input frequency must by greater then 50 MHz.");
+            assign clk_en = '0;
+        end
+
     endgenerate
 
     //------------------------------------------------------------------------


### PR DESCRIPTION
Ознакомился с модулем для `INMP441`. Сейчас модуль поддерживает только 2 частоты 100 и 50 MHz.

Для решения проблемы:
- Вынес PLL c тактовым сигналом`serial_clk` с частотой 125 MHz из под `ifdef`
- Пробросил `serial_clk` до `slow_clock_gen` который генерирует сигнал c на 50 MHz
- Подключил приёмник микрофона на новый тактовый сигнал.

Для данного решения есть альтернативы:
- Использовать PLL
- Переписать модуль `inmp441_mic_i2s_receiver` на параметрическую частоту (выше 50 MHz)