### PR TITLE
Fixes frequency detection with inmp441

### DIFF
--- a/labs/3_music/3_1_note_recognizer/lab_top.sv
+++ b/labs/3_music/3_1_note_recognizer/lab_top.sv
@@ -1,5 +1,9 @@
 `include "config.svh"
 
+// Enable a period-averaging note filter instead of a time-based one
+`define NOTE_PERIOD_COUNTING_AVERAGING_FILTER
+
+
 module lab_top
 # (
     parameter  clk_mhz       = 50,
@@ -72,6 +76,7 @@ module lab_top
     //
     //  Exercise 1: Uncomment this instantation
     //  to see the value coming from the microphone (in hexadecimal).
+    //  Comment out a "The output to seven segment display" section below.
     //
     //------------------------------------------------------------------------
 
@@ -86,6 +91,50 @@ module lab_top
     //  Measuring frequency
     //
     //------------------------------------------------------------------------
+
+    // Filter out noise by averaging over several periods of the wave.
+    `ifdef NOTE_PERIOD_COUNTING_AVERAGING_FILTER
+
+    // It is enough for the counter to be 24 bit. Why?
+    
+    logic [23:0] prev_mic;
+    logic [23:0] counter;
+    localparam int w_period_count = $clog2(440/4); // Measure 440 Hz note ~4 times a second
+    logic [w_period_count - 1:0] period_counter; // average over several wave periods
+    logic [19:0] distance;
+
+    always_ff @ (posedge clk or posedge rst)
+        if (rst)
+        begin
+            prev_mic <= '0;
+            counter  <= '0;
+            period_counter <= '0;
+            distance <= '0;
+        end
+        else
+        begin
+            prev_mic <= mic;
+
+            // Crossing from negative to positive numbers
+
+            if (  prev_mic [$left ( prev_mic )] == 1'b1
+                & mic      [$left ( mic      )] == 1'b0 )
+            begin
+                period_counter = period_counter + 1'b1;
+                if (& period_counter)
+                begin
+                    distance <= counter / (1 << w_period_count); // estimate cycles per period
+                    counter <= '0;
+                end
+                else
+                    counter <= counter + 1'b1;
+            end
+            else if (counter != '1)  // To prevent overflow
+                counter <= counter + 1'b1;
+        end
+
+    // Filter out noise by checking note value over a period of time.
+    `else
 
     // It is enough for the counter to be 20 bit. Why?
 
@@ -110,33 +159,45 @@ module lab_top
                 & mic      [$left ( mic      )] == 1'b0 )
             begin
                distance <= counter;
-               counter  <= 20'h0;
+               counter  <= '0;
             end
-            else if (counter != ~ 20'h0)  // To prevent overflow
+            else if (counter != '1)  // To prevent overflow
             begin
-               counter <= counter + 20'h1;
+               counter <= counter + 1'b1;
             end
         end
 
+    `endif
+
     //------------------------------------------------------------------------
     //
-    //  Exercise 2: Uncomment this instantation
-    //  to see the value of the counter.
+    //  Exercise 2: Uncomment this instantation 
+    //  to see the value of the counter. 
     //
     //------------------------------------------------------------------------
 
     // seven_segment_display # (w_digit)
-    // i_7segment (.number (w_number' (counter)), .*);
+    // i_7segment (.number (w_number' (period_counter)), .*);
 
     //------------------------------------------------------------------------
     //
     //  Exercise 3: Uncomment this instantation
-    //  to see the period of the sound wave coming from the microphone.
+    //  to see the period of the sound wave in cycles coming from the microphone.
     //
     //------------------------------------------------------------------------
 
     // seven_segment_display # (w_digit)
-    // i_7segment (.number (w_number' (distance [19:4])), .*);
+    // i_7segment (.number (w_number' (distance)), .*);
+
+    //------------------------------------------------------------------------
+    //
+    //  Exercise 4: Uncomment this instantation
+    //  to see the frequency of the sound wave coming from the microphone.
+    //
+    //------------------------------------------------------------------------
+
+    // seven_segment_display # (w_digit)
+    // i_7segment (.number (w_number' (clk_mhz * 1000 * 1000 / distance)), .*);
 
     //------------------------------------------------------------------------
     //
@@ -146,18 +207,19 @@ module lab_top
 
     `ifdef USE_STANDARD_FREQUENCIES
 
-    localparam freq_100_C  = 26163,
-               freq_100_Cs = 27718,
-               freq_100_D  = 29366,
-               freq_100_Ds = 31113,
-               freq_100_E  = 32963,
-               freq_100_F  = 34923,
-               freq_100_Fs = 36999,
-               freq_100_G  = 39200,
-               freq_100_Gs = 41530,
-               freq_100_A  = 44000,
-               freq_100_As = 46616,
-               freq_100_B  = 49388;
+    // Standard note frequencies using A440 (Stuttgart pitch standard): https://en.wikipedia.org/wiki/A440_(pitch_standard)
+    localparam freq_100_C  = 26163, // 261.63 Hz for 'C' note: https://en.wikipedia.org/wiki/C_(musical_note)
+               freq_100_Cs = 27718, // 277.18 Hz for 'C#' note: https://en.wikipedia.org/wiki/C_(musical_note)
+               freq_100_D  = 29366, // 293.66 Hz for 'D' note: https://en.wikipedia.org/wiki/D_(musical_note)
+               freq_100_Ds = 31113, // 311.13 Hz for 'D#' note: https://en.wikipedia.org/wiki/D_(musical_note)
+               freq_100_E  = 32963, // 329.63 Hz for 'E' note: https://en.wikipedia.org/wiki/E_(musical_note)
+               freq_100_F  = 34923, // 349.23 Hz for 'F' note: https://en.wikipedia.org/wiki/F_(musical_note)
+               freq_100_Fs = 36999, // 369.99 Hz for 'F#' note: https://en.wikipedia.org/wiki/F_(musical_note)
+               freq_100_G  = 39200, // 392 Hz for 'G' note: https://en.wikipedia.org/wiki/G_(musical_note)
+               freq_100_Gs = 41530, // 415.30 Hz for 'G#' note: https://en.wikipedia.org/wiki/G_(musical_note)
+               freq_100_A  = 44000, // 440 Hz for 'A' note: https://en.wikipedia.org/wiki/A_(musical_note) 
+               freq_100_As = 46616, // 466.16 Hz for 'A#' note: https://en.wikipedia.org/wiki/A_(musical_note)
+               freq_100_B  = 49388; // 493.88 Hz for 'B' note: https://en.wikipedia.org/wiki/B_(musical_note)
     `else
 
     // Custom measured frequencies
@@ -179,13 +241,13 @@ module lab_top
     //------------------------------------------------------------------------
 
     function [19:0] high_distance (input [18:0] freq_100);
-       high_distance = clk_mhz * 1000 * 1000 / freq_100 * 103;
+       high_distance = clk_mhz * 1000 * 1000 * 103 / freq_100;
     endfunction
 
     //------------------------------------------------------------------------
 
     function [19:0] low_distance (input [18:0] freq_100);
-       low_distance = clk_mhz * 1000 * 1000 / freq_100 * 97;
+       low_distance = clk_mhz * 1000 * 1000 * 97 / freq_100;
     endfunction
 
     //------------------------------------------------------------------------
@@ -202,7 +264,8 @@ module lab_top
 
        check_freq =   check_freq_single_range (freq_100 * 4 , distance)
                     | check_freq_single_range (freq_100 * 2 , distance)
-                    | check_freq_single_range (freq_100     , distance);
+                    | check_freq_single_range (freq_100     , distance)
+                    | check_freq_single_range (freq_100 / 2 , distance);
 
     endfunction
 
@@ -260,24 +323,25 @@ module lab_top
         else
             d_note <= note;
 
-    logic  [19:0] t_cnt;           // Threshold counter
-    logic  [w_note - 1:0] t_note;  // Thresholded note
+    localparam int w_t_cnt = $clog2(clk_mhz * 1000 * 1000 / 10); // Filter ~N times a second
+    logic  [w_t_cnt - 1:0] f_cnt;         // Filter counter
+    logic  [w_note - 1:0] filtered_note;  // Filtered note
 
     always_ff @ (posedge clk or posedge rst)
         if (rst)
-            t_cnt <= 0;
+            f_cnt <= '0;
         else
             if (note == d_note)
-                t_cnt <= t_cnt + 1;
+                f_cnt <= f_cnt + 1'b1; // Increase the counter if note has not changed
             else
-                t_cnt <= 0;
+                f_cnt <= '0;
 
     always_ff @ (posedge clk or posedge rst)
         if (rst)
-            t_note <= no_note;
+            filtered_note <= no_note;
         else
-            if (& t_cnt)
-                t_note <= d_note;
+            if (& f_cnt)
+                filtered_note <= d_note; // If the counter is full, update the filtered note
 
     //------------------------------------------------------------------------
     //
@@ -289,7 +353,7 @@ module lab_top
         if (rst)
             abcdefgh <= 8'b00000000;
         else
-            case (t_note)
+            case (filtered_note)
             C  : abcdefgh <= 8'b10011100;  // C   // abcdefgh
             Cs : abcdefgh <= 8'b10011101;  // C#
             D  : abcdefgh <= 8'b01111010;  // D   //   --a--
@@ -302,14 +366,14 @@ module lab_top
             A  : abcdefgh <= 8'b11101110;  // A   //  |     |
             As : abcdefgh <= 8'b11101111;  // A#  //   --d--  h
             B  : abcdefgh <= 8'b00111110;  // B
-            default : abcdefgh <= 8'b00000000;
+            default : abcdefgh <= 8'b00000000; // Invalid notes
             endcase
 
     assign digit = w_digit' (1);
 
     //------------------------------------------------------------------------
     //
-    //  Exercise 4: Replace filtered note with unfiltered note.
+    //  Exercise 5: Replace filtered note with unfiltered note.
     //  Do you see the difference?
     //
     //------------------------------------------------------------------------

--- a/peripherals/inmp441_mic_i2s_receiver.sv
+++ b/peripherals/inmp441_mic_i2s_receiver.sv
@@ -1,4 +1,10 @@
-// Asynchronous reset here is needed for one of FPGA boards we use
+// The INMP441 microphone is a digital microphone that outputs I2S data.
+
+// This module receives the clock and outputs a 24-bit value.
+// The INMP441 microphone outputs 64-bit words, with the first 24 bits being the left channel.
+// The remaining bits are ignored.
+// See https://invensense.tdk.com/wp-content/uploads/2015/02/INMP441.pdf for details
+// Note: Asynchronous reset here is needed for one of FPGA boards we use.
 
 `include "config.svh"
 
@@ -7,81 +13,85 @@ module inmp441_mic_i2s_receiver
     parameter clk_mhz = 50
 )
 (
-    input               clk,
-    input               rst,
-    output              lr,
-    output logic        ws,
-    output              sck,
-    input               sd,
-    output logic [23:0] value
+    input               clk, // Clock
+    input               rst, // Reset
+    output              lr, // Request data to be sent in left or right I2S channel
+    output logic        ws, // I2S word select (left or right channel)
+    output logic        sck, // I2S clock
+    input               sd, // I2S data
+    output logic [23:0] value // 24-bit value
 );
 
-    assign lr = 1'b0;
+    assign lr = 1'b0; // Left channel (we ignore the right channel)
 
     //------------------------------------------------------------------------
 
-    logic clk_en;
-
-    generate
-        if (clk_mhz == 100)
-        begin : clk_100
-            always_ff @ (posedge clk or posedge rst)
-                if (rst)
-                    clk_en <= '0;
-                else
-                    clk_en <= ~ clk_en;
-        end
-        else
-        begin : not_clk_100
-            assign clk_en = '1;
-        end
-    endgenerate
-
-    //------------------------------------------------------------------------
-
-    logic [8:0] cnt;
+    // Drive SCK at 1/(2*sck_clock_divisor) of the clock frequency.
+    // INMP441: Accepts SCK frequency 0.5-3.2 MHz, WS frequency 7.8-50 KHz
+    // We will target SCK at or below 3 Mhz, and WS at or below 46.9 Khz 
+    // For example: 
+    //   clk 50 MHz -> 9 cycles -> sck clock at 2.777 Mhz, ws at 43.4 Khz
+    //   clk 27 MHz -> 5 cycles -> sck clock at 2.7 Mhz, ws at 42.2 Khz 
+    localparam int sck_clock_divisor = $ceil(1.0 * clk_mhz / 3 / 2);
+    logic [$clog2(sck_clock_divisor) - 1:0] cnt; // Counter used to drive SCK 
+    logic       sck_posedge; // Tracks SCK posedge 
+    logic       sck_negedge; // Tracks SCK negedge 
 
     always_ff @ (posedge clk or posedge rst)
         if (rst)
             cnt <= '0;
-        else if (clk_en)
-            cnt <= cnt + 1'd1;
+            sck_posedge <= '0;
+            sck_negedge <= '0;
+        else
+            if (cnt == sck_clock_divisor - 1'b1) // Every N cycles drive SCK up or down
+            begin
+                sck <= ~ sck;
+                cnt <= '0;
+                if (~ sck)
+                    sck_posedge <= '1;
+                else
+                    sck_negedge <= '1;
+            end
+            else
+            begin
+                cnt <= cnt + 1'b1;
+                sck_posedge <= '0;
+                sck_negedge <= '0;
+            end
 
     //------------------------------------------------------------------------
 
-    assign sck = cnt [3];                // 50 MHz / 16   = 3.13 MHz
+    logic [5:0] cnt_sd; // Counter bit within a 64-bit SD-driven word
+    logic [23:0] shift; // 24-bit value accumulator
 
-    always_ff @ (posedge clk or posedge rst)
-        if (rst)
-            ws <= 1'b1;
-        else if (clk_en & cnt == 9'd15)  // 50 MHz / 1024 = 48.8  KHz
-            ws <= ~ ws;
-
-    wire sample_bit
-        =    ws == lr
-          && cnt >= 9'd39                // 1.5 sck cycle
-          && cnt <= 9' (39 + 23 * 16)    // sampling 0 to 23
-          && cnt [3:0] == 4'd7;          // posedge sck
-
-    wire value_done = (ws == lr) & (cnt == '1);
-
-
-    //------------------------------------------------------------------------
-
-    logic [23:0] shift;
-
+     // Update SD on the rising edge of SCK, and may be capture 1-bit of data
     always_ff @ (posedge clk or posedge rst)
         if (rst)
         begin
+            cnt_sd <= '0;
             shift <= '0;
-            value <= '0;
         end
-        else if (clk_en)
+        else if (sck_posedge)
         begin
-            if (sample_bit)
-                shift <= { shift [22:0], sd };
-            else if (value_done)
-                value <= shift;
+            cnt_sd <= cnt_sd + 1'b1;
+            // INMP441: 64-bit SD-driven word, with 2-25 and 34-57 bits being valid 24 bits of data
+            if (cnt_sd >= 6'd2 && cnt_sd <= 6'd25 || cnt_sd >= 6'd34 && cnt_sd <= 6'd57)
+                shift <= {shift [22:0], sd}; // capture 1 bit from SD
+        end
+
+    // Update WS on the falling edge of SCK, and output 24-bit value
+    always_ff @ (posedge clk or posedge rst)
+        if (rst)
+            ws <= '0;
+        else if (sck_negedge)
+        begin
+            ws <= cnt_sd[5]; // 0 for 0-31, 1 for 32-63
+            if (cnt_sd == 6'd0 || cnt_sd == 6'd31)
+                if (ws == lr) // only capture channel we have requested data from
+                    // Bad soldering may result in unexepcted values to be captured,
+                    // valid values are up to around 100K
+                    if (shift[23-:6] == '0 || shift[23-:6] == '1) 
+                        value <= shift; // capture 24-bit value
         end
 
 endmodule


### PR DESCRIPTION
This commit refactors the inmp441_mic_i2s_receiver module
- A clock divisor based on a board clock frequency is used to drive SCK. This ensures inmp441 is always driven at the frequency it can support.
- A base protocol is re-implemented to better match the specification to align with both positive and negative edges of SCK.
- Basic filtering was added. Real microphones sometimes sent invalid data over the wire, these values are now filtered out and ignored.

Additionally, improve code in a note_recognizer lab to average distance over mulitple sound wave periods for increased percision. Additionally, one more exercise was added to output the actual measured frequency. This drastically simplifies debugging when clocks of the board and microphone are a bit off.