### PR TITLE
Introducing CI actions for testing (with Quartus currently)

### DIFF
--- a/.github/workflows/synthesis.yml
+++ b/.github/workflows/synthesis.yml
@@ -1,0 +1,54 @@
+name: Synthesis check
+
+on:
+  pull_request:
+    branches: [main]
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+env:
+  USER: root
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+
+jobs:
+  linux-testing:
+    name: ${{ matrix.tool }}_${{ matrix.imagever }}
+    runs-on: ['ubuntu-latest']
+    container:
+      image: ${{ matrix.imagerepo }}:${{ matrix.imagever }}
+    timeout-minutes: 45
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - tool: quartus
+            imagerepo: ghcr.io/raetro/quartus
+            imagever: 21.1.1
+            boards: 40
+            labs: 12345
+          - tool: quartus
+            imagerepo: ghcr.io/raetro/quartus
+            imagever: 13.0sp1
+            boards: 9 35
+            labs: 12345
+    steps:
+      - name: Checkout
+        run: |
+          # Avoid https://github.com/actions/checkout/issues/1590
+          curl -L -o archive.tar.gz https://github.com/${GITHUB_REPOSITORY}/archive/${GITHUB_SHA}.tar.gz
+          tar xvf archive.tar.gz; env; pwd; ls *${GITHUB_SHA}
+      - name: Synthesis
+        shell: bash
+        run: |
+          set -ex; cd *${GITHUB_SHA}
+          echo >scripts/steps/04_configure_fpga.source_bash # disable programmator
+          for b in ${{ matrix.boards }}; do
+            echo -e "$b\ny\n" | ./check_setup_and_choose_fpga_board.bash
+            for x in labs/[${{ matrix.labs }}]_*/*_*_*/03_synthesize_for_fpga.bash; do
+                pushd `dirname $x`
+                echo | ./`basename $x`
+                popd
+            done
+          done


### PR DESCRIPTION
Github actions are enabled for Pull Requests (only, do you want for main branch?). Currently, Quartus 13 & 21 on labs 1-5 for boards 9, 35,40 are used for testing, but this is easily configurable using the following settings in the file:
```yaml
      matrix:
        include:
          - tool: quartus
            imagerepo: ghcr.io/raetro/quartus
            imagever: 21.1.1
            boards: 9 40
            labs: 12345
```
* To add a new synthesis tool, please find a docker image and specify it as `imagerepo:` in a copy of `- tool:` entry with everything until the next section.
* To change a version of existing tool (e.g. quartus), please find it in a docker repository, e.g. https://ghcr.io/raetro/quartus, and change `imagever:`
* To change a set of board configurations to test, specify a space-separated list in `boards:`
* If you want to extend or reduce the number of labs to test, change `labs:` with a digit of the lab, e.g. `labs: 123` for testing labs 1-3