### PR TITLE
Correction of clock frequency errors, assigning 49 MHz to the main frequency for Gowin Primer 20k

### DIFF
--- a/boards/tang_nano_20k_lcd_800_480_tm1638/board_specific_top.sv
+++ b/boards/tang_nano_20k_lcd_800_480_tm1638/board_specific_top.sv
@@ -13,8 +13,8 @@
 
 module board_specific_top
 # (
-    parameter clk_mhz       = 27,
-              pixel_mhz     = 25,
+    parameter clk_mhz       = 27, // CLK
+              pixel_mhz     = 49, // LCD_CLK
 
               w_key         = 2,  // The last key is used for a reset
               w_sw          = 0,
@@ -281,13 +281,13 @@ module board_specific_top
 
     `ifdef INSTANTIATE_GRAPHICS_INTERFACE_MODULE
 
-        wire lcd_module_clk;
+        wire high_clk;
 
         Gowin_rPLL i_Gowin_rPLL
         (
-            .clkout  ( lcd_module_clk ),  // 200    MHz
-            .clkoutd ( LCD_CLK        ),  //  33.33 MHz
-            .clkin   ( clk            )   //  27    MHz
+            .clkout  ( high_clk       ),  //  391.5  MHz
+            .clkoutd ( LCD_CLK        ),  //  48.938 MHz
+            .clkin   ( clk            )   //  27     MHz
         );
 
         lcd_800_480 i_lcd

--- a/boards/tang_nano_20k_lcd_800_480_tm1638/gowin_rpll.v
+++ b/boards/tang_nano_20k_lcd_800_480_tm1638/gowin_rpll.v
@@ -5,7 +5,7 @@
 //Part Number: GW2A-LV18PG256C8/I7
 //Device: GW2A-18
 //Device Version: C
-//Created Time: Sun Nov 10 02:51:25 2024
+//Created Time: Tue Nov 12 02:15:41 2024
 
 module Gowin_rPLL (clkout, clkoutd, clkin);
 
@@ -40,11 +40,11 @@ rPLL rpll_inst (
 
 defparam rpll_inst.FCLKIN = "27";
 defparam rpll_inst.DYN_IDIV_SEL = "false";
-defparam rpll_inst.IDIV_SEL = 0;
+defparam rpll_inst.IDIV_SEL = 1;
 defparam rpll_inst.DYN_FBDIV_SEL = "false";
-defparam rpll_inst.FBDIV_SEL = 2;
+defparam rpll_inst.FBDIV_SEL = 28;
 defparam rpll_inst.DYN_ODIV_SEL = "false";
-defparam rpll_inst.ODIV_SEL = 8;
+defparam rpll_inst.ODIV_SEL = 2;
 defparam rpll_inst.PSDA_SEL = "0000";
 defparam rpll_inst.DYN_DA_EN = "true";
 defparam rpll_inst.DUTYDA_SEL = "1000";
@@ -56,7 +56,7 @@ defparam rpll_inst.CLKFB_SEL = "internal";
 defparam rpll_inst.CLKOUT_BYPASS = "false";
 defparam rpll_inst.CLKOUTP_BYPASS = "false";
 defparam rpll_inst.CLKOUTD_BYPASS = "false";
-defparam rpll_inst.DYN_SDIV_SEL = 2;
+defparam rpll_inst.DYN_SDIV_SEL = 8;
 defparam rpll_inst.CLKOUTD_SRC = "CLKOUT";
 defparam rpll_inst.CLKOUTD3_SRC = "CLKOUT";
 defparam rpll_inst.DEVICE = "GW2A-18C";

--- a/boards/tang_primer_20k_dock_lcd_800_480_no_tm1638/gowin_rpll.v
+++ b/boards/tang_primer_20k_dock_lcd_800_480_no_tm1638/gowin_rpll.v
@@ -5,7 +5,7 @@
 //Part Number: GW2A-LV18PG256C8/I7
 //Device: GW2A-18
 //Device Version: C
-//Created Time: Sun Nov 10 02:51:25 2024
+//Created Time: Tue Nov 12 02:15:41 2024
 
 module Gowin_rPLL (clkout, clkoutd, clkin);
 
@@ -40,11 +40,11 @@ rPLL rpll_inst (
 
 defparam rpll_inst.FCLKIN = "27";
 defparam rpll_inst.DYN_IDIV_SEL = "false";
-defparam rpll_inst.IDIV_SEL = 0;
+defparam rpll_inst.IDIV_SEL = 1;
 defparam rpll_inst.DYN_FBDIV_SEL = "false";
-defparam rpll_inst.FBDIV_SEL = 2;
+defparam rpll_inst.FBDIV_SEL = 28;
 defparam rpll_inst.DYN_ODIV_SEL = "false";
-defparam rpll_inst.ODIV_SEL = 8;
+defparam rpll_inst.ODIV_SEL = 2;
 defparam rpll_inst.PSDA_SEL = "0000";
 defparam rpll_inst.DYN_DA_EN = "true";
 defparam rpll_inst.DUTYDA_SEL = "1000";
@@ -56,7 +56,7 @@ defparam rpll_inst.CLKFB_SEL = "internal";
 defparam rpll_inst.CLKOUT_BYPASS = "false";
 defparam rpll_inst.CLKOUTP_BYPASS = "false";
 defparam rpll_inst.CLKOUTD_BYPASS = "false";
-defparam rpll_inst.DYN_SDIV_SEL = 2;
+defparam rpll_inst.DYN_SDIV_SEL = 8;
 defparam rpll_inst.CLKOUTD_SRC = "CLKOUT";
 defparam rpll_inst.CLKOUTD3_SRC = "CLKOUT";
 defparam rpll_inst.DEVICE = "GW2A-18C";

--- a/boards/tang_primer_20k_dock_lcd_800_480_tm1638/gowin_rpll.v
+++ b/boards/tang_primer_20k_dock_lcd_800_480_tm1638/gowin_rpll.v
@@ -5,7 +5,7 @@
 //Part Number: GW2A-LV18PG256C8/I7
 //Device: GW2A-18
 //Device Version: C
-//Created Time: Sun Nov 10 02:51:25 2024
+//Created Time: Tue Nov 12 02:15:41 2024
 
 module Gowin_rPLL (clkout, clkoutd, clkin);
 
@@ -40,11 +40,11 @@ rPLL rpll_inst (
 
 defparam rpll_inst.FCLKIN = "27";
 defparam rpll_inst.DYN_IDIV_SEL = "false";
-defparam rpll_inst.IDIV_SEL = 0;
+defparam rpll_inst.IDIV_SEL = 1;
 defparam rpll_inst.DYN_FBDIV_SEL = "false";
-defparam rpll_inst.FBDIV_SEL = 2;
+defparam rpll_inst.FBDIV_SEL = 28;
 defparam rpll_inst.DYN_ODIV_SEL = "false";
-defparam rpll_inst.ODIV_SEL = 8;
+defparam rpll_inst.ODIV_SEL = 2;
 defparam rpll_inst.PSDA_SEL = "0000";
 defparam rpll_inst.DYN_DA_EN = "true";
 defparam rpll_inst.DUTYDA_SEL = "1000";
@@ -56,7 +56,7 @@ defparam rpll_inst.CLKFB_SEL = "internal";
 defparam rpll_inst.CLKOUT_BYPASS = "false";
 defparam rpll_inst.CLKOUTP_BYPASS = "false";
 defparam rpll_inst.CLKOUTD_BYPASS = "false";
-defparam rpll_inst.DYN_SDIV_SEL = 2;
+defparam rpll_inst.DYN_SDIV_SEL = 8;
 defparam rpll_inst.CLKOUTD_SRC = "CLKOUT";
 defparam rpll_inst.CLKOUTD3_SRC = "CLKOUT";
 defparam rpll_inst.DEVICE = "GW2A-18C";

--- a/peripherals/lcd_800_480.sv
+++ b/peripherals/lcd_800_480.sv
@@ -1,7 +1,8 @@
-// This module is created based on https://github.com/sipeed/TangNano-9K-example/lcd_led/src/VGAMod.v
+// This module is created based on https://github.com/sipeed/TangNano-9K-example/blob/main/lcd_led/src/VGAMod.v
 
 module lcd_800_480
 (
+    // input                CLK,  Modified for basic-graphics-music: not used
     input                   nRST,
 
     input                   PixelClk,
@@ -29,23 +30,23 @@ module lcd_800_480
     reg         [15:0]  PixelCount;
     reg         [15:0]  LineCount;
 
-    localparam      V_BackPorch = 16'd0; //6
+    localparam      V_BackPorch = 16'd0;  //6
     localparam      V_Pluse     = 16'd5;
     localparam      HightPixel  = 16'd480;
     localparam      V_FrontPorch= 16'd45; //62
 
-    localparam      H_BackPorch = 16'd182;     //NOTE: 高像素时钟时，增加这里的延迟，方便K210加入中断
+    localparam      H_BackPorch = 16'd182;  //NOTE: 高像素时钟时，增加这里的延迟，方便K210加入中断
     localparam      H_Pluse     = 16'd1;
     localparam      WidthPixel  = 16'd800;
     localparam      H_FrontPorch= 16'd210;
 
-    parameter       BarCount    = 16; // RGB565
+    parameter       BarCount    = 16;  // RGB565
     localparam      Width_bar   = WidthPixel / 16;
 
     localparam      PixelForHS  =   WidthPixel + H_BackPorch + H_FrontPorch;
     localparam      LineForVS   =   HightPixel + V_BackPorch + V_FrontPorch;
 
-    always @(  posedge PixelClk or negedge nRST  )begin
+    always @( posedge PixelClk or negedge nRST ) begin
         if( !nRST ) begin
             LineCount       <=  16'b0;
             PixelCount      <=  16'b0;
@@ -66,7 +67,7 @@ module lcd_800_480
     reg            [9:0]  Data_G;
     reg            [9:0]  Data_B;
 
-    always @(  posedge PixelClk or negedge nRST  )begin
+    always @( posedge PixelClk or negedge nRST ) begin
         if( !nRST ) begin
             Data_R <= 9'b0;
             Data_G <= 9'b0;
@@ -75,11 +76,11 @@ module lcd_800_480
     end
     //注意这里HSYNC和VSYNC负极性
     assign  LCD_HSYNC = (( PixelCount >= H_Pluse)&&( PixelCount <= (PixelForHS-H_FrontPorch))) ? 1'b0 : 1'b1;
-    //assign  LCD_VSYNC = ((( LineCount  >= 0 )&&( LineCount  <= (V_Pluse-1) )) ) ? 1'b1 : 1'b0;        //这里不减一的话，图片底部会往下拖尾？
+    //assign  LCD_VSYNC = ((( LineCount  >= 0 )&&( LineCount  <= (V_Pluse-1) )) ) ? 1'b1 : 1'b0;      //这里不减一的话，图片底部会往下拖尾？
     assign  LCD_VSYNC = ((( LineCount  >= V_Pluse )&&( LineCount  <= (LineForVS-0) )) ) ? 1'b0 : 1'b1;
     //assign  FIFO_RST  = (( PixelCount ==0)) ? 1'b1 : 1'b0;  //留给主机H_BackPorch的时间进入中断，发送数据
 
-    assign  LCD_DE = (  ( PixelCount >= H_BackPorch )&&
+    assign  LCD_DE = (  ( PixelCount >= H_BackPorch ) &&
                         ( PixelCount <= PixelForHS-H_FrontPorch ) &&
                         ( LineCount >= V_BackPorch ) &&
                         ( LineCount <= LineForVS-V_FrontPorch-1 ))  ? 1'b1 : 1'b0;


### PR DESCRIPTION
Исправил ошибки в gowin_rpll.v Исправил в board_specific_top.sv значения частот pixel_mhz на правильные. Сделал 49 МГц основной частотой. Поправил пробелы и вернул закомментированным CLK в lcd_800_480.sv