### PR TITLE
Onboard audio codec support for Terasic boards

### DIFF
--- a/boards/de1/I2C_AUDIO_Config.v
+++ b/boards/de1/I2C_AUDIO_Config.v
@@ -1,0 +1,174 @@
+// --------------------------------------------------------------------
+// Copyright (c) 2005 by Terasic Technologies Inc.
+// --------------------------------------------------------------------
+//
+// Permission:
+//
+//   Terasic grants permission to use and modify this code for use
+//   in synthesis for all Terasic Development Boards and Altrea Development
+//   Kits made by Terasic.  Other use of this code, including the selling
+//   ,duplication, or modification of any portion is strictly prohibited.
+//
+// Disclaimer:
+//
+//   This VHDL or Verilog source code is intended as a design reference
+//   which illustrates how these types of functions can be implemented.
+//   It is the user's responsibility to verify their design for
+//   consistency and functionality through the use of formal
+//   verification methods.  Terasic provides no warranty regarding the use
+//   or functionality of this code.
+//
+// --------------------------------------------------------------------
+//
+//                     Terasic Technologies Inc
+//                     356 Fu-Shin E. Rd Sec. 1. JhuBei City,
+//                     HsinChu County, Taiwan
+//                     302
+//
+//                     web: http://www.terasic.com/
+//                     email: support@terasic.com
+//
+// --------------------------------------------------------------------
+
+module I2C_AUDIO_Config (	//	Host Side
+					iCLK,
+					iRST_N,
+					//	I2C Side
+					I2C_SCLK,
+					I2C_SDAT,
+					READY
+					 );
+//	Host Side
+input				iCLK;
+input				iRST_N;
+//	I2C Side
+output			I2C_SCLK;
+inout				I2C_SDAT;
+output READY;
+
+//	Internal Registers/Wires
+reg	[15:0]	mI2C_CLK_DIV;
+reg	[23:0]	mI2C_DATA;
+reg				mI2C_CTRL_CLK;
+reg				mI2C_GO;
+wire				mI2C_END;
+wire				mI2C_ACK;
+reg	[15:0]	LUT_DATA;
+reg	[5:0]		LUT_INDEX;
+reg	[3:0]		mSetup_ST;
+reg READY ;
+
+//  Clock Setting
+parameter   CLK_Freq     =   50000000;   //  50  MHz
+parameter   I2C_Freq     =   20000;      //  20  KHz
+//  LUT Data Number
+parameter   LUT_SIZE     =   11;
+//	Audio Data Index
+parameter	Dummy_DATA	=	0;
+parameter	SET_LIN_L	=	1;
+parameter	SET_LIN_R	=	2;
+parameter	SET_HEAD_L	=	3;
+parameter	SET_HEAD_R	=	4;
+parameter	A_PATH_CTRL	=	5;
+parameter	D_PATH_CTRL	=	6;
+parameter	POWER_ON	=	7;
+parameter	SET_FORMAT	=	8;
+parameter	SAMPLE_CTRL	=	9;
+parameter	SET_ACTIVE	=	10;
+//  Audio codec I2C address
+parameter   AUD_I2C_ADDR =   8'h34;
+
+/////////////////////	I2C Control Clock	////////////////////////
+always@(posedge iCLK or negedge iRST_N)
+begin
+	if(!iRST_N)
+	begin
+		mI2C_CTRL_CLK	<=	0;
+		mI2C_CLK_DIV	<=	0;
+	end
+	else
+	begin
+		if( mI2C_CLK_DIV	< (CLK_Freq/I2C_Freq) )
+			mI2C_CLK_DIV	<=	mI2C_CLK_DIV+1;
+		else
+		begin
+			mI2C_CLK_DIV	<=	0;
+			mI2C_CTRL_CLK	<=	~mI2C_CTRL_CLK;
+		end
+	end
+end
+////////////////////////////////////////////////////////////////////
+I2C_Controller 	u0	(	.CLOCK(mI2C_CTRL_CLK),	//	Controller Work Clock
+						.I2C_SCLK(I2C_SCLK),				//	I2C CLOCK
+ 	 	 	 	 	 	.I2C_SDAT(I2C_SDAT),				//	I2C DATA
+						.I2C_DATA(mI2C_DATA),			//	DATA:[SLAVE_ADDR,SUB_ADDR,DATA]
+						.GO(mI2C_GO),						//	GO transfor
+						.END(mI2C_END),					//	END transfor
+						.ACK(mI2C_ACK),					//	ACK
+						.RESET(iRST_N)	);
+////////////////////////////////////////////////////////////////////
+//////////////////////	Config Control	////////////////////////////
+always@(posedge mI2C_CTRL_CLK or negedge iRST_N)
+begin
+	if(!iRST_N)
+	begin
+		READY		<=	0;
+		LUT_INDEX	<=	0;
+		mSetup_ST	<=	0;
+		mI2C_GO		<=	0;
+	end
+	else
+	begin
+		if(LUT_INDEX<LUT_SIZE)
+		begin
+		READY<=0;
+			case(mSetup_ST)
+			0:	begin
+					mI2C_DATA	<=	{AUD_I2C_ADDR,LUT_DATA};
+					mI2C_GO		<=	1;
+					mSetup_ST	<=	1;
+				end
+			1:	begin
+					if(mI2C_END)
+					begin
+						if(!mI2C_ACK)
+						mSetup_ST	<=	2;
+						else
+						mSetup_ST	<=	0;
+						mI2C_GO		<=	0;
+					end
+				end
+			2:	begin
+					LUT_INDEX	<=	LUT_INDEX+1;
+					mSetup_ST	<=	0;
+				end
+			endcase
+		end
+		else
+		begin
+		  READY<=1;
+		end
+	end
+end
+////////////////////////////////////////////////////////////////////
+/////////////////////	Config Data LUT	  //////////////////////////	
+always
+begin
+    case(LUT_INDEX)
+    //  Audio Config Data: 7 bit reg address + 9 bits of data
+    Dummy_DATA  :   LUT_DATA <= 16'h0000;
+    SET_LIN_L   :   LUT_DATA <= 16'h0017;   //R0 LINVOL = 17h (+0.0bB)
+    SET_LIN_R   :   LUT_DATA <= 16'h0217;   //R1 RINVOL = 17h (+0.0bB)
+    SET_HEAD_L  :   LUT_DATA <= 16'h0460;   //R2 LHPVOL = 60h (-43dB)
+    SET_HEAD_R  :   LUT_DATA <= 16'h0660;   //R3 RHPVOL = 60h (-43dB)
+    A_PATH_CTRL :   LUT_DATA <= 16'h08D2;   //R4 DACSEL = 1
+    D_PATH_CTRL :   LUT_DATA <= 16'h0A06;   //R5 DEEMP = 11 (48 KHz)
+    POWER_ON    :   LUT_DATA <= 16'h0C00;   //R6 PWR_CTL = 00h (disable power down)
+    SET_FORMAT  :   LUT_DATA <= 16'h0E02;   //R7 FORMAT=10(I2S), 16 bit
+    SAMPLE_CTRL :   LUT_DATA <= 16'h1002;   //R8 48KHz, Normal mode
+    SET_ACTIVE  :   LUT_DATA <= 16'h1201;   //R9 ACTIVE
+    default     :   LUT_DATA <= 16'h0000;
+    endcase
+end
+////////////////////////////////////////////////////////////////////
+endmodule

--- a/boards/de1/I2C_Controller.v
+++ b/boards/de1/I2C_Controller.v
@@ -1,0 +1,75 @@
+// --------------------------------------------------------------------
+// Copyright (c) 2005 by Terasic Technologies Inc.
+// --------------------------------------------------------------------
+//
+// Permission:
+//
+//   Terasic grants permission to use and modify this code for use
+//   in synthesis for all Terasic Development Boards and Altrea Development
+//   Kits made by Terasic.  Other use of this code, including the selling
+//   ,duplication, or modification of any portion is strictly prohibited.
+//
+// Disclaimer:
+//
+//   This VHDL or Verilog source code is intended as a design reference
+//   which illustrates how these types of functions can be implemented.
+//   It is the user's responsibility to verify their design for
+//   consistency and functionality through the use of formal
+//   verification methods.  Terasic provides no warranty regarding the use
+//   or functionality of this code.
+//
+// --------------------------------------------------------------------
+//
+//                     Terasic Technologies Inc
+//                     356 Fu-Shin E. Rd Sec. 1. JhuBei City,
+//                     HsinChu County, Taiwan
+//                     302
+//
+//                     web: http://www.terasic.com/
+//                     email: support@terasic.com
+//
+// --------------------------------------------------------------------
+//
+// Major Functions:i2c controller
+//
+// --------------------------------------------------------------------
+//
+// Revision History :
+// --------------------------------------------------------------------
+//   Ver  :| Author            :| Mod. Date :| Changes Made:
+//   V1.0 :| Joe Yang          :| 05/07/10  :|      Initial Revision
+//   V2.0 :| Joe Yang          :| 12/12/16  :|      Initial Revision
+// --------------------------------------------------------------------
+module I2C_Controller (
+	input  CLOCK,
+	input  [23:0]I2C_DATA,
+	input  GO,
+	input  RESET,
+	input  W_R,
+ 	inout  I2C_SDAT,
+	output I2C_SCLK,
+	output END,
+	output ACK
+);
+
+wire SDAO ;
+
+assign I2C_SDAT = SDAO?1'bz :0  ;
+
+I2C_WRITE_WDATA  wrd(
+   .RESET_N  ( RESET),
+	.PT_CK    ( CLOCK),
+	.GO       ( GO   ),
+	.END_OK   ( END  ),
+	.ACK_OK   ( ACK  ),
+	.BYTE_NUM ( 2    ),  //2byte
+	.SDAI     ( I2C_SDAT ),//IN
+	.SDAO     ( SDAO     ),//OUT
+	.SCLO     ( I2C_SCLK ),
+	.SLAVE_ADDRESS( I2C_DATA[23:16] ),
+	.REG_DATA     ( I2C_DATA[15:0]  )
+);
+
+
+
+endmodule

--- a/boards/de1/I2C_WRITE_WDATA.v
+++ b/boards/de1/I2C_WRITE_WDATA.v
@@ -1,0 +1,138 @@
+// --------------------------------------------------------------------
+// Copyright (c) 2005 by Terasic Technologies Inc.
+// --------------------------------------------------------------------
+//
+// Permission:
+//
+//   Terasic grants permission to use and modify this code for use
+//   in synthesis for all Terasic Development Boards and Altrea Development
+//   Kits made by Terasic.  Other use of this code, including the selling
+//   ,duplication, or modification of any portion is strictly prohibited.
+//
+// Disclaimer:
+//
+//   This VHDL or Verilog source code is intended as a design reference
+//   which illustrates how these types of functions can be implemented.
+//   It is the user's responsibility to verify their design for
+//   consistency and functionality through the use of formal
+//   verification methods.  Terasic provides no warranty regarding the use
+//   or functionality of this code.
+//
+// --------------------------------------------------------------------
+//
+//                     Terasic Technologies Inc
+//                     356 Fu-Shin E. Rd Sec. 1. JhuBei City,
+//                     HsinChu County, Taiwan
+//                     302
+//
+//                     web: http://www.terasic.com/
+//                     email: support@terasic.com
+//
+// --------------------------------------------------------------------
+
+module I2C_WRITE_WDATA  (
+   input  				RESET_N ,
+	input      		  	PT_CK,
+	input      		  	GO,
+	input      [15:0] REG_DATA,
+	input      [7:0] 	SLAVE_ADDRESS,
+	input            	SDAI,
+	output reg       	SDAO,
+	output reg       	SCLO,
+	output reg       	END_OK,
+
+	//--for test
+	output reg [7:0] 	ST ,
+	output reg [7:0] 	CNT,
+	output reg [7:0] 	BYTE,
+	output reg       	ACK_OK,
+   input      [7:0]  BYTE_NUM  // 4 : 4 byte
+);
+
+//===reg/wire
+reg   [8:0]A ;
+reg   [7:0]DELY ;
+
+always @( negedge RESET_N or posedge  PT_CK )begin
+if (!RESET_N  ) ST <=0;
+else
+	  case (ST)
+	    0: begin  //start
+		      SDAO   <=1;
+	         SCLO   <=1;
+	         ACK_OK <=0;
+	         CNT    <=0;
+	         END_OK <=1;
+	         BYTE   <=0;
+	         if (GO) ST  <=30 ; // inital
+		    end
+	    1: begin  //start
+		      ST <=2 ;
+			   { SDAO,  SCLO } <= 2'b01;
+				A <= {SLAVE_ADDRESS ,1'b1 };//WRITE COMMAND
+		    end
+	    2: begin  //start
+		      ST <=3 ;
+			   { SDAO,  SCLO } <= 2'b00;
+		    end
+
+	    3: begin
+		      ST <=4 ;
+			   { SDAO, A } <= { A ,1'b0 };
+		    end
+	    4: begin
+		      ST <=5 ;
+			   SCLO <= 1'b1 ;
+				CNT <= CNT +1 ;
+		    end
+
+	    5: begin
+			   SCLO <= 1'b0 ;
+			   if (CNT==9) begin
+				     if ( BYTE == BYTE_NUM )  ST <= 6 ;
+					  else  begin
+					           CNT <=0 ;
+					           ST <= 2 ;
+					                if ( BYTE ==0 ) begin BYTE <=1  ; A <= {REG_DATA[15:8] ,1'b1 }; end
+					           else if ( BYTE ==1 ) begin BYTE <=2  ; A <= {REG_DATA[7:0] ,1'b1 }; end
+							  end
+					  if (SDAI ) ACK_OK <=1 ;
+				 end
+				 else ST <= 2;
+		    end
+
+	    6: begin          //stop
+		      ST <=7 ;
+			   { SDAO,  SCLO } <= 2'b00;
+         end
+
+	    7: begin          //stop
+		      ST <=8 ;
+			   { SDAO,  SCLO } <= 2'b01;
+         end
+	    8: begin          //stop
+		      ST <=9 ;
+			   { SDAO,  SCLO } <= 2'b11;
+
+         end
+		9:	begin
+		      ST     <= 30;
+				SDAO   <=1;
+	         SCLO   <=1;
+	         CNT    <=0;
+	         END_OK <=1;
+	         BYTE   <=0;
+		     end
+		//--- END ---
+		   30: begin
+            if (!GO) ST  <=31;
+          end
+		   31: begin  //
+		      END_OK<=0;
+				ACK_OK<=0;
+				ST    <=1;
+			end
+	  endcase
+ end
+
+endmodule

--- a/boards/de1/board_specific.qsf
+++ b/boards/de1/board_specific.qsf
@@ -96,6 +96,16 @@ set_location_assignment PIN_D11 -to VGA_B[1]
 set_location_assignment PIN_A10 -to VGA_B[2]
 set_location_assignment PIN_B10 -to VGA_B[3]
 
+set_location_assignment PIN_A6 -to AUD_ADCLRCK
+set_location_assignment PIN_B6 -to AUD_ADCDAT
+set_location_assignment PIN_A5 -to AUD_DACLRCK
+set_location_assignment PIN_B5 -to AUD_DACDAT
+set_location_assignment PIN_B4 -to AUD_XCK
+set_location_assignment PIN_A4 -to AUD_BCLK
+
+set_location_assignment PIN_A3 -to I2C_SCLK
+set_location_assignment PIN_B3 -to I2C_SDAT
+
 set_location_assignment PIN_A13 -to GPIO_0[0]
 set_location_assignment PIN_B13 -to GPIO_0[1]
 set_location_assignment PIN_A14 -to GPIO_0[2]

--- a/boards/de1/board_specific_top.sv
+++ b/boards/de1/board_specific_top.sv
@@ -13,7 +13,6 @@ module board_specific_top
               w_gpio        = 72,        // GPIO_1[5:0] reserved for mic
 
               // gpio 0..5 are reserved for INMP 441 I2S microphone.
-              // Odd gpio .. are reserved I2S audio.
 
               screen_width  = 640,
               screen_height = 480,
@@ -43,6 +42,16 @@ module board_specific_top
     output [ w_red      - 1:0] VGA_R,
     output [ w_green    - 1:0] VGA_G,
     output [ w_blue     - 1:0] VGA_B,
+
+    output                     AUD_ADCLRCK,
+    input                      AUD_ADCDAT,
+    inout                      AUD_BCLK,
+    output                     AUD_DACLRCK,
+    output                     AUD_DACDAT,
+    output                     AUD_XCK,
+
+    output                     I2C_SCLK,
+    inout                      I2C_SDAT,
 
     input                      UART_RXD,
     output                     UART_TXD,
@@ -266,19 +275,30 @@ module board_specific_top
 
     `ifdef INSTANTIATE_SOUND_OUTPUT_INTERFACE_MODULE
 
+        // DE1 onboard audio codec: WM8731
         i2s_audio_out
         # (
-            .clk_mhz ( clk_mhz     )
+            .clk_mhz ( clk_mhz      )
         )
-        inst_audio_out
+        i_audio_out
         (
-            .clk     ( clk         ),
-            .reset   ( rst         ),
-            .data_in ( sound       ),
-            .mclk    ( GPIO_1 [33] ),
-            .bclk    ( GPIO_1 [31] ),
-            .lrclk   ( GPIO_1 [27] ),
-            .sdata   ( GPIO_1 [29] )
+            .clk     ( clk          ),
+            .reset   ( rst          ),
+            .data_in ( sound        ),
+            .mclk    ( AUD_XCK      ),
+            .bclk    ( AUD_BCLK     ),
+            .lrclk   ( AUD_DACLRCK  ),
+            .sdata   ( AUD_DACDAT   )
+        );
+
+        // The audio codec configuration
+        I2C_AUDIO_Config
+        i_i2c_codec_conf (
+            .iCLK    (clk),
+            .iRST_N  (~rst),
+            .I2C_SCLK(I2C_SCLK),
+            .I2C_SDAT(I2C_SDAT),
+            .READY   ()
         );
 
     `endif

--- a/boards/de1_soc/I2C_AUDIO_Config.v
+++ b/boards/de1_soc/I2C_AUDIO_Config.v
@@ -1,0 +1,174 @@
+// --------------------------------------------------------------------
+// Copyright (c) 2005 by Terasic Technologies Inc.
+// --------------------------------------------------------------------
+//
+// Permission:
+//
+//   Terasic grants permission to use and modify this code for use
+//   in synthesis for all Terasic Development Boards and Altrea Development
+//   Kits made by Terasic.  Other use of this code, including the selling
+//   ,duplication, or modification of any portion is strictly prohibited.
+//
+// Disclaimer:
+//
+//   This VHDL or Verilog source code is intended as a design reference
+//   which illustrates how these types of functions can be implemented.
+//   It is the user's responsibility to verify their design for
+//   consistency and functionality through the use of formal
+//   verification methods.  Terasic provides no warranty regarding the use
+//   or functionality of this code.
+//
+// --------------------------------------------------------------------
+//
+//                     Terasic Technologies Inc
+//                     356 Fu-Shin E. Rd Sec. 1. JhuBei City,
+//                     HsinChu County, Taiwan
+//                     302
+//
+//                     web: http://www.terasic.com/
+//                     email: support@terasic.com
+//
+// --------------------------------------------------------------------
+
+module I2C_AUDIO_Config (	//	Host Side
+					iCLK,
+					iRST_N,
+					//	I2C Side
+					I2C_SCLK,
+					I2C_SDAT,
+					READY
+					 );
+//	Host Side
+input				iCLK;
+input				iRST_N;
+//	I2C Side
+output			I2C_SCLK;
+inout				I2C_SDAT;
+output READY;
+
+//	Internal Registers/Wires
+reg	[15:0]	mI2C_CLK_DIV;
+reg	[23:0]	mI2C_DATA;
+reg				mI2C_CTRL_CLK;
+reg				mI2C_GO;
+wire				mI2C_END;
+wire				mI2C_ACK;
+reg	[15:0]	LUT_DATA;
+reg	[5:0]		LUT_INDEX;
+reg	[3:0]		mSetup_ST;
+reg READY ;
+
+//  Clock Setting
+parameter   CLK_Freq     =   50000000;   //  50  MHz
+parameter   I2C_Freq     =   20000;      //  20  KHz
+//  LUT Data Number
+parameter   LUT_SIZE     =   11;
+//	Audio Data Index
+parameter	Dummy_DATA	=	0;
+parameter	SET_LIN_L	=	1;
+parameter	SET_LIN_R	=	2;
+parameter	SET_HEAD_L	=	3;
+parameter	SET_HEAD_R	=	4;
+parameter	A_PATH_CTRL	=	5;
+parameter	D_PATH_CTRL	=	6;
+parameter	POWER_ON	=	7;
+parameter	SET_FORMAT	=	8;
+parameter	SAMPLE_CTRL	=	9;
+parameter	SET_ACTIVE	=	10;
+//  Audio codec I2C address
+parameter   AUD_I2C_ADDR =   8'h34;
+
+/////////////////////	I2C Control Clock	////////////////////////
+always@(posedge iCLK or negedge iRST_N)
+begin
+	if(!iRST_N)
+	begin
+		mI2C_CTRL_CLK	<=	0;
+		mI2C_CLK_DIV	<=	0;
+	end
+	else
+	begin
+		if( mI2C_CLK_DIV	< (CLK_Freq/I2C_Freq) )
+			mI2C_CLK_DIV	<=	mI2C_CLK_DIV+1;
+		else
+		begin
+			mI2C_CLK_DIV	<=	0;
+			mI2C_CTRL_CLK	<=	~mI2C_CTRL_CLK;
+		end
+	end
+end
+////////////////////////////////////////////////////////////////////
+I2C_Controller 	u0	(	.CLOCK(mI2C_CTRL_CLK),	//	Controller Work Clock
+						.I2C_SCLK(I2C_SCLK),				//	I2C CLOCK
+ 	 	 	 	 	 	.I2C_SDAT(I2C_SDAT),				//	I2C DATA
+						.I2C_DATA(mI2C_DATA),			//	DATA:[SLAVE_ADDR,SUB_ADDR,DATA]
+						.GO(mI2C_GO),						//	GO transfor
+						.END(mI2C_END),					//	END transfor
+						.ACK(mI2C_ACK),					//	ACK
+						.RESET(iRST_N)	);
+////////////////////////////////////////////////////////////////////
+//////////////////////	Config Control	////////////////////////////
+always@(posedge mI2C_CTRL_CLK or negedge iRST_N)
+begin
+	if(!iRST_N)
+	begin
+		READY		<=	0;
+		LUT_INDEX	<=	0;
+		mSetup_ST	<=	0;
+		mI2C_GO		<=	0;
+	end
+	else
+	begin
+		if(LUT_INDEX<LUT_SIZE)
+		begin
+		READY<=0;
+			case(mSetup_ST)
+			0:	begin
+					mI2C_DATA	<=	{AUD_I2C_ADDR,LUT_DATA};
+					mI2C_GO		<=	1;
+					mSetup_ST	<=	1;
+				end
+			1:	begin
+					if(mI2C_END)
+					begin
+						if(!mI2C_ACK)
+						mSetup_ST	<=	2;
+						else
+						mSetup_ST	<=	0;
+						mI2C_GO		<=	0;
+					end
+				end
+			2:	begin
+					LUT_INDEX	<=	LUT_INDEX+1;
+					mSetup_ST	<=	0;
+				end
+			endcase
+		end
+		else
+		begin
+		  READY<=1;
+		end
+	end
+end
+////////////////////////////////////////////////////////////////////
+/////////////////////	Config Data LUT	  //////////////////////////	
+always
+begin
+    case(LUT_INDEX)
+    //  Audio Config Data: 7 bit reg address + 9 bits of data
+    Dummy_DATA  :   LUT_DATA <= 16'h0000;
+    SET_LIN_L   :   LUT_DATA <= 16'h0017;   //R0 LINVOL = 17h (+0.0bB)
+    SET_LIN_R   :   LUT_DATA <= 16'h0217;   //R1 RINVOL = 17h (+0.0bB)
+    SET_HEAD_L  :   LUT_DATA <= 16'h0460;   //R2 LHPVOL = 60h (-43dB)
+    SET_HEAD_R  :   LUT_DATA <= 16'h0660;   //R3 RHPVOL = 60h (-43dB)
+    A_PATH_CTRL :   LUT_DATA <= 16'h08D2;   //R4 DACSEL = 1
+    D_PATH_CTRL :   LUT_DATA <= 16'h0A06;   //R5 DEEMP = 11 (48 KHz)
+    POWER_ON    :   LUT_DATA <= 16'h0C00;   //R6 PWR_CTL = 00h (disable power down)
+    SET_FORMAT  :   LUT_DATA <= 16'h0E02;   //R7 FORMAT=10(I2S), 16 bit
+    SAMPLE_CTRL :   LUT_DATA <= 16'h1002;   //R8 48KHz, Normal mode
+    SET_ACTIVE  :   LUT_DATA <= 16'h1201;   //R9 ACTIVE
+    default     :   LUT_DATA <= 16'h0000;
+    endcase
+end
+////////////////////////////////////////////////////////////////////
+endmodule

--- a/boards/de1_soc/I2C_Controller.v
+++ b/boards/de1_soc/I2C_Controller.v
@@ -1,0 +1,75 @@
+// --------------------------------------------------------------------
+// Copyright (c) 2005 by Terasic Technologies Inc.
+// --------------------------------------------------------------------
+//
+// Permission:
+//
+//   Terasic grants permission to use and modify this code for use
+//   in synthesis for all Terasic Development Boards and Altrea Development
+//   Kits made by Terasic.  Other use of this code, including the selling
+//   ,duplication, or modification of any portion is strictly prohibited.
+//
+// Disclaimer:
+//
+//   This VHDL or Verilog source code is intended as a design reference
+//   which illustrates how these types of functions can be implemented.
+//   It is the user's responsibility to verify their design for
+//   consistency and functionality through the use of formal
+//   verification methods.  Terasic provides no warranty regarding the use
+//   or functionality of this code.
+//
+// --------------------------------------------------------------------
+//
+//                     Terasic Technologies Inc
+//                     356 Fu-Shin E. Rd Sec. 1. JhuBei City,
+//                     HsinChu County, Taiwan
+//                     302
+//
+//                     web: http://www.terasic.com/
+//                     email: support@terasic.com
+//
+// --------------------------------------------------------------------
+//
+// Major Functions:i2c controller
+//
+// --------------------------------------------------------------------
+//
+// Revision History :
+// --------------------------------------------------------------------
+//   Ver  :| Author            :| Mod. Date :| Changes Made:
+//   V1.0 :| Joe Yang          :| 05/07/10  :|      Initial Revision
+//   V2.0 :| Joe Yang          :| 12/12/16  :|      Initial Revision
+// --------------------------------------------------------------------
+module I2C_Controller (
+	input  CLOCK,
+	input  [23:0]I2C_DATA,
+	input  GO,
+	input  RESET,
+	input  W_R,
+ 	inout  I2C_SDAT,
+	output I2C_SCLK,
+	output END,
+	output ACK
+);
+
+wire SDAO ;
+
+assign I2C_SDAT = SDAO?1'bz :0  ;
+
+I2C_WRITE_WDATA  wrd(
+   .RESET_N  ( RESET),
+	.PT_CK    ( CLOCK),
+	.GO       ( GO   ),
+	.END_OK   ( END  ),
+	.ACK_OK   ( ACK  ),
+	.BYTE_NUM ( 2    ),  //2byte
+	.SDAI     ( I2C_SDAT ),//IN
+	.SDAO     ( SDAO     ),//OUT
+	.SCLO     ( I2C_SCLK ),
+	.SLAVE_ADDRESS( I2C_DATA[23:16] ),
+	.REG_DATA     ( I2C_DATA[15:0]  )
+);
+
+
+
+endmodule

--- a/boards/de1_soc/I2C_WRITE_WDATA.v
+++ b/boards/de1_soc/I2C_WRITE_WDATA.v
@@ -1,0 +1,138 @@
+// --------------------------------------------------------------------
+// Copyright (c) 2005 by Terasic Technologies Inc.
+// --------------------------------------------------------------------
+//
+// Permission:
+//
+//   Terasic grants permission to use and modify this code for use
+//   in synthesis for all Terasic Development Boards and Altrea Development
+//   Kits made by Terasic.  Other use of this code, including the selling
+//   ,duplication, or modification of any portion is strictly prohibited.
+//
+// Disclaimer:
+//
+//   This VHDL or Verilog source code is intended as a design reference
+//   which illustrates how these types of functions can be implemented.
+//   It is the user's responsibility to verify their design for
+//   consistency and functionality through the use of formal
+//   verification methods.  Terasic provides no warranty regarding the use
+//   or functionality of this code.
+//
+// --------------------------------------------------------------------
+//
+//                     Terasic Technologies Inc
+//                     356 Fu-Shin E. Rd Sec. 1. JhuBei City,
+//                     HsinChu County, Taiwan
+//                     302
+//
+//                     web: http://www.terasic.com/
+//                     email: support@terasic.com
+//
+// --------------------------------------------------------------------
+
+module I2C_WRITE_WDATA  (
+   input  				RESET_N ,
+	input      		  	PT_CK,
+	input      		  	GO,
+	input      [15:0] REG_DATA,
+	input      [7:0] 	SLAVE_ADDRESS,
+	input            	SDAI,
+	output reg       	SDAO,
+	output reg       	SCLO,
+	output reg       	END_OK,
+
+	//--for test
+	output reg [7:0] 	ST ,
+	output reg [7:0] 	CNT,
+	output reg [7:0] 	BYTE,
+	output reg       	ACK_OK,
+   input      [7:0]  BYTE_NUM  // 4 : 4 byte
+);
+
+//===reg/wire
+reg   [8:0]A ;
+reg   [7:0]DELY ;
+
+always @( negedge RESET_N or posedge  PT_CK )begin
+if (!RESET_N  ) ST <=0;
+else
+	  case (ST)
+	    0: begin  //start
+		      SDAO   <=1;
+	         SCLO   <=1;
+	         ACK_OK <=0;
+	         CNT    <=0;
+	         END_OK <=1;
+	         BYTE   <=0;
+	         if (GO) ST  <=30 ; // inital
+		    end
+	    1: begin  //start
+		      ST <=2 ;
+			   { SDAO,  SCLO } <= 2'b01;
+				A <= {SLAVE_ADDRESS ,1'b1 };//WRITE COMMAND
+		    end
+	    2: begin  //start
+		      ST <=3 ;
+			   { SDAO,  SCLO } <= 2'b00;
+		    end
+
+	    3: begin
+		      ST <=4 ;
+			   { SDAO, A } <= { A ,1'b0 };
+		    end
+	    4: begin
+		      ST <=5 ;
+			   SCLO <= 1'b1 ;
+				CNT <= CNT +1 ;
+		    end
+
+	    5: begin
+			   SCLO <= 1'b0 ;
+			   if (CNT==9) begin
+				     if ( BYTE == BYTE_NUM )  ST <= 6 ;
+					  else  begin
+					           CNT <=0 ;
+					           ST <= 2 ;
+					                if ( BYTE ==0 ) begin BYTE <=1  ; A <= {REG_DATA[15:8] ,1'b1 }; end
+					           else if ( BYTE ==1 ) begin BYTE <=2  ; A <= {REG_DATA[7:0] ,1'b1 }; end
+							  end
+					  if (SDAI ) ACK_OK <=1 ;
+				 end
+				 else ST <= 2;
+		    end
+
+	    6: begin          //stop
+		      ST <=7 ;
+			   { SDAO,  SCLO } <= 2'b00;
+         end
+
+	    7: begin          //stop
+		      ST <=8 ;
+			   { SDAO,  SCLO } <= 2'b01;
+         end
+	    8: begin          //stop
+		      ST <=9 ;
+			   { SDAO,  SCLO } <= 2'b11;
+
+         end
+		9:	begin
+		      ST     <= 30;
+				SDAO   <=1;
+	         SCLO   <=1;
+	         CNT    <=0;
+	         END_OK <=1;
+	         BYTE   <=0;
+		     end
+		//--- END ---
+		   30: begin
+            if (!GO) ST  <=31;
+          end
+		   31: begin  //
+		      END_OK<=0;
+				ACK_OK<=0;
+				ST    <=1;
+			end
+	  endcase
+ end
+
+endmodule

--- a/boards/de2/I2C_AUDIO_Config.v
+++ b/boards/de2/I2C_AUDIO_Config.v
@@ -1,0 +1,174 @@
+// --------------------------------------------------------------------
+// Copyright (c) 2005 by Terasic Technologies Inc.
+// --------------------------------------------------------------------
+//
+// Permission:
+//
+//   Terasic grants permission to use and modify this code for use
+//   in synthesis for all Terasic Development Boards and Altrea Development
+//   Kits made by Terasic.  Other use of this code, including the selling
+//   ,duplication, or modification of any portion is strictly prohibited.
+//
+// Disclaimer:
+//
+//   This VHDL or Verilog source code is intended as a design reference
+//   which illustrates how these types of functions can be implemented.
+//   It is the user's responsibility to verify their design for
+//   consistency and functionality through the use of formal
+//   verification methods.  Terasic provides no warranty regarding the use
+//   or functionality of this code.
+//
+// --------------------------------------------------------------------
+//
+//                     Terasic Technologies Inc
+//                     356 Fu-Shin E. Rd Sec. 1. JhuBei City,
+//                     HsinChu County, Taiwan
+//                     302
+//
+//                     web: http://www.terasic.com/
+//                     email: support@terasic.com
+//
+// --------------------------------------------------------------------
+
+module I2C_AUDIO_Config (	//	Host Side
+					iCLK,
+					iRST_N,
+					//	I2C Side
+					I2C_SCLK,
+					I2C_SDAT,
+					READY
+					 );
+//	Host Side
+input				iCLK;
+input				iRST_N;
+//	I2C Side
+output			I2C_SCLK;
+inout				I2C_SDAT;
+output READY;
+
+//	Internal Registers/Wires
+reg	[15:0]	mI2C_CLK_DIV;
+reg	[23:0]	mI2C_DATA;
+reg				mI2C_CTRL_CLK;
+reg				mI2C_GO;
+wire				mI2C_END;
+wire				mI2C_ACK;
+reg	[15:0]	LUT_DATA;
+reg	[5:0]		LUT_INDEX;
+reg	[3:0]		mSetup_ST;
+reg READY ;
+
+//  Clock Setting
+parameter   CLK_Freq     =   50000000;   //  50  MHz
+parameter   I2C_Freq     =   20000;      //  20  KHz
+//  LUT Data Number
+parameter   LUT_SIZE     =   11;
+//	Audio Data Index
+parameter	Dummy_DATA	=	0;
+parameter	SET_LIN_L	=	1;
+parameter	SET_LIN_R	=	2;
+parameter	SET_HEAD_L	=	3;
+parameter	SET_HEAD_R	=	4;
+parameter	A_PATH_CTRL	=	5;
+parameter	D_PATH_CTRL	=	6;
+parameter	POWER_ON	=	7;
+parameter	SET_FORMAT	=	8;
+parameter	SAMPLE_CTRL	=	9;
+parameter	SET_ACTIVE	=	10;
+//  Audio codec I2C address
+parameter   AUD_I2C_ADDR =   8'h34;
+
+/////////////////////	I2C Control Clock	////////////////////////
+always@(posedge iCLK or negedge iRST_N)
+begin
+	if(!iRST_N)
+	begin
+		mI2C_CTRL_CLK	<=	0;
+		mI2C_CLK_DIV	<=	0;
+	end
+	else
+	begin
+		if( mI2C_CLK_DIV	< (CLK_Freq/I2C_Freq) )
+			mI2C_CLK_DIV	<=	mI2C_CLK_DIV+1;
+		else
+		begin
+			mI2C_CLK_DIV	<=	0;
+			mI2C_CTRL_CLK	<=	~mI2C_CTRL_CLK;
+		end
+	end
+end
+////////////////////////////////////////////////////////////////////
+I2C_Controller 	u0	(	.CLOCK(mI2C_CTRL_CLK),	//	Controller Work Clock
+						.I2C_SCLK(I2C_SCLK),				//	I2C CLOCK
+ 	 	 	 	 	 	.I2C_SDAT(I2C_SDAT),				//	I2C DATA
+						.I2C_DATA(mI2C_DATA),			//	DATA:[SLAVE_ADDR,SUB_ADDR,DATA]
+						.GO(mI2C_GO),						//	GO transfor
+						.END(mI2C_END),					//	END transfor
+						.ACK(mI2C_ACK),					//	ACK
+						.RESET(iRST_N)	);
+////////////////////////////////////////////////////////////////////
+//////////////////////	Config Control	////////////////////////////
+always@(posedge mI2C_CTRL_CLK or negedge iRST_N)
+begin
+	if(!iRST_N)
+	begin
+		READY		<=	0;
+		LUT_INDEX	<=	0;
+		mSetup_ST	<=	0;
+		mI2C_GO		<=	0;
+	end
+	else
+	begin
+		if(LUT_INDEX<LUT_SIZE)
+		begin
+		READY<=0;
+			case(mSetup_ST)
+			0:	begin
+					mI2C_DATA	<=	{AUD_I2C_ADDR,LUT_DATA};
+					mI2C_GO		<=	1;
+					mSetup_ST	<=	1;
+				end
+			1:	begin
+					if(mI2C_END)
+					begin
+						if(!mI2C_ACK)
+						mSetup_ST	<=	2;
+						else
+						mSetup_ST	<=	0;
+						mI2C_GO		<=	0;
+					end
+				end
+			2:	begin
+					LUT_INDEX	<=	LUT_INDEX+1;
+					mSetup_ST	<=	0;
+				end
+			endcase
+		end
+		else
+		begin
+		  READY<=1;
+		end
+	end
+end
+////////////////////////////////////////////////////////////////////
+/////////////////////	Config Data LUT	  //////////////////////////	
+always
+begin
+    case(LUT_INDEX)
+    //  Audio Config Data: 7 bit reg address + 9 bits of data
+    Dummy_DATA  :   LUT_DATA <= 16'h0000;
+    SET_LIN_L   :   LUT_DATA <= 16'h0017;   //R0 LINVOL = 17h (+0.0bB)
+    SET_LIN_R   :   LUT_DATA <= 16'h0217;   //R1 RINVOL = 17h (+0.0bB)
+    SET_HEAD_L  :   LUT_DATA <= 16'h0460;   //R2 LHPVOL = 60h (-43dB)
+    SET_HEAD_R  :   LUT_DATA <= 16'h0660;   //R3 RHPVOL = 60h (-43dB)
+    A_PATH_CTRL :   LUT_DATA <= 16'h08D2;   //R4 DACSEL = 1
+    D_PATH_CTRL :   LUT_DATA <= 16'h0A06;   //R5 DEEMP = 11 (48 KHz)
+    POWER_ON    :   LUT_DATA <= 16'h0C00;   //R6 PWR_CTL = 00h (disable power down)
+    SET_FORMAT  :   LUT_DATA <= 16'h0E02;   //R7 FORMAT=10(I2S), 16 bit
+    SAMPLE_CTRL :   LUT_DATA <= 16'h1002;   //R8 48KHz, Normal mode
+    SET_ACTIVE  :   LUT_DATA <= 16'h1201;   //R9 ACTIVE
+    default     :   LUT_DATA <= 16'h0000;
+    endcase
+end
+////////////////////////////////////////////////////////////////////
+endmodule

--- a/boards/de2/I2C_Controller.v
+++ b/boards/de2/I2C_Controller.v
@@ -1,0 +1,75 @@
+// --------------------------------------------------------------------
+// Copyright (c) 2005 by Terasic Technologies Inc.
+// --------------------------------------------------------------------
+//
+// Permission:
+//
+//   Terasic grants permission to use and modify this code for use
+//   in synthesis for all Terasic Development Boards and Altrea Development
+//   Kits made by Terasic.  Other use of this code, including the selling
+//   ,duplication, or modification of any portion is strictly prohibited.
+//
+// Disclaimer:
+//
+//   This VHDL or Verilog source code is intended as a design reference
+//   which illustrates how these types of functions can be implemented.
+//   It is the user's responsibility to verify their design for
+//   consistency and functionality through the use of formal
+//   verification methods.  Terasic provides no warranty regarding the use
+//   or functionality of this code.
+//
+// --------------------------------------------------------------------
+//
+//                     Terasic Technologies Inc
+//                     356 Fu-Shin E. Rd Sec. 1. JhuBei City,
+//                     HsinChu County, Taiwan
+//                     302
+//
+//                     web: http://www.terasic.com/
+//                     email: support@terasic.com
+//
+// --------------------------------------------------------------------
+//
+// Major Functions:i2c controller
+//
+// --------------------------------------------------------------------
+//
+// Revision History :
+// --------------------------------------------------------------------
+//   Ver  :| Author            :| Mod. Date :| Changes Made:
+//   V1.0 :| Joe Yang          :| 05/07/10  :|      Initial Revision
+//   V2.0 :| Joe Yang          :| 12/12/16  :|      Initial Revision
+// --------------------------------------------------------------------
+module I2C_Controller (
+	input  CLOCK,
+	input  [23:0]I2C_DATA,
+	input  GO,
+	input  RESET,
+	input  W_R,
+ 	inout  I2C_SDAT,
+	output I2C_SCLK,
+	output END,
+	output ACK
+);
+
+wire SDAO ;
+
+assign I2C_SDAT = SDAO?1'bz :0  ;
+
+I2C_WRITE_WDATA  wrd(
+   .RESET_N  ( RESET),
+	.PT_CK    ( CLOCK),
+	.GO       ( GO   ),
+	.END_OK   ( END  ),
+	.ACK_OK   ( ACK  ),
+	.BYTE_NUM ( 2    ),  //2byte
+	.SDAI     ( I2C_SDAT ),//IN
+	.SDAO     ( SDAO     ),//OUT
+	.SCLO     ( I2C_SCLK ),
+	.SLAVE_ADDRESS( I2C_DATA[23:16] ),
+	.REG_DATA     ( I2C_DATA[15:0]  )
+);
+
+
+
+endmodule

--- a/boards/de2/I2C_WRITE_WDATA.v
+++ b/boards/de2/I2C_WRITE_WDATA.v
@@ -1,0 +1,138 @@
+// --------------------------------------------------------------------
+// Copyright (c) 2005 by Terasic Technologies Inc.
+// --------------------------------------------------------------------
+//
+// Permission:
+//
+//   Terasic grants permission to use and modify this code for use
+//   in synthesis for all Terasic Development Boards and Altrea Development
+//   Kits made by Terasic.  Other use of this code, including the selling
+//   ,duplication, or modification of any portion is strictly prohibited.
+//
+// Disclaimer:
+//
+//   This VHDL or Verilog source code is intended as a design reference
+//   which illustrates how these types of functions can be implemented.
+//   It is the user's responsibility to verify their design for
+//   consistency and functionality through the use of formal
+//   verification methods.  Terasic provides no warranty regarding the use
+//   or functionality of this code.
+//
+// --------------------------------------------------------------------
+//
+//                     Terasic Technologies Inc
+//                     356 Fu-Shin E. Rd Sec. 1. JhuBei City,
+//                     HsinChu County, Taiwan
+//                     302
+//
+//                     web: http://www.terasic.com/
+//                     email: support@terasic.com
+//
+// --------------------------------------------------------------------
+
+module I2C_WRITE_WDATA  (
+   input  				RESET_N ,
+	input      		  	PT_CK,
+	input      		  	GO,
+	input      [15:0] REG_DATA,
+	input      [7:0] 	SLAVE_ADDRESS,
+	input            	SDAI,
+	output reg       	SDAO,
+	output reg       	SCLO,
+	output reg       	END_OK,
+
+	//--for test
+	output reg [7:0] 	ST ,
+	output reg [7:0] 	CNT,
+	output reg [7:0] 	BYTE,
+	output reg       	ACK_OK,
+   input      [7:0]  BYTE_NUM  // 4 : 4 byte
+);
+
+//===reg/wire
+reg   [8:0]A ;
+reg   [7:0]DELY ;
+
+always @( negedge RESET_N or posedge  PT_CK )begin
+if (!RESET_N  ) ST <=0;
+else
+	  case (ST)
+	    0: begin  //start
+		      SDAO   <=1;
+	         SCLO   <=1;
+	         ACK_OK <=0;
+	         CNT    <=0;
+	         END_OK <=1;
+	         BYTE   <=0;
+	         if (GO) ST  <=30 ; // inital
+		    end
+	    1: begin  //start
+		      ST <=2 ;
+			   { SDAO,  SCLO } <= 2'b01;
+				A <= {SLAVE_ADDRESS ,1'b1 };//WRITE COMMAND
+		    end
+	    2: begin  //start
+		      ST <=3 ;
+			   { SDAO,  SCLO } <= 2'b00;
+		    end
+
+	    3: begin
+		      ST <=4 ;
+			   { SDAO, A } <= { A ,1'b0 };
+		    end
+	    4: begin
+		      ST <=5 ;
+			   SCLO <= 1'b1 ;
+				CNT <= CNT +1 ;
+		    end
+
+	    5: begin
+			   SCLO <= 1'b0 ;
+			   if (CNT==9) begin
+				     if ( BYTE == BYTE_NUM )  ST <= 6 ;
+					  else  begin
+					           CNT <=0 ;
+					           ST <= 2 ;
+					                if ( BYTE ==0 ) begin BYTE <=1  ; A <= {REG_DATA[15:8] ,1'b1 }; end
+					           else if ( BYTE ==1 ) begin BYTE <=2  ; A <= {REG_DATA[7:0] ,1'b1 }; end
+							  end
+					  if (SDAI ) ACK_OK <=1 ;
+				 end
+				 else ST <= 2;
+		    end
+
+	    6: begin          //stop
+		      ST <=7 ;
+			   { SDAO,  SCLO } <= 2'b00;
+         end
+
+	    7: begin          //stop
+		      ST <=8 ;
+			   { SDAO,  SCLO } <= 2'b01;
+         end
+	    8: begin          //stop
+		      ST <=9 ;
+			   { SDAO,  SCLO } <= 2'b11;
+
+         end
+		9:	begin
+		      ST     <= 30;
+				SDAO   <=1;
+	         SCLO   <=1;
+	         CNT    <=0;
+	         END_OK <=1;
+	         BYTE   <=0;
+		     end
+		//--- END ---
+		   30: begin
+            if (!GO) ST  <=31;
+          end
+		   31: begin  //
+		      END_OK<=0;
+				ACK_OK<=0;
+				ST    <=1;
+			end
+	  endcase
+ end
+
+endmodule

--- a/boards/de2/board_specific.qsf
+++ b/boards/de2/board_specific.qsf
@@ -159,6 +159,16 @@ set_location_assignment PIN_B11  -to VGA_B[7]
 set_location_assignment PIN_C12  -to VGA_B[8]
 set_location_assignment PIN_B12  -to VGA_B[9]
 
+set_location_assignment PIN_C5   -to AUD_ADCLRCK
+set_location_assignment PIN_B5   -to AUD_ADCDAT
+set_location_assignment PIN_B4   -to AUD_BCLK
+set_location_assignment PIN_C6   -to AUD_DACLRCK
+set_location_assignment PIN_A4   -to AUD_DACDAT
+set_location_assignment PIN_A5   -to AUD_XCK
+
+set_location_assignment PIN_A6   -to I2C_SCLK
+set_location_assignment PIN_B6   -to I2C_SDAT
+
 set_location_assignment PIN_D25 -to GPIO_0[0]
 set_location_assignment PIN_J22 -to GPIO_0[1]
 set_location_assignment PIN_E26 -to GPIO_0[2]

--- a/boards/de2_115/I2C_AUDIO_Config.v
+++ b/boards/de2_115/I2C_AUDIO_Config.v
@@ -1,0 +1,174 @@
+// --------------------------------------------------------------------
+// Copyright (c) 2005 by Terasic Technologies Inc.
+// --------------------------------------------------------------------
+//
+// Permission:
+//
+//   Terasic grants permission to use and modify this code for use
+//   in synthesis for all Terasic Development Boards and Altrea Development
+//   Kits made by Terasic.  Other use of this code, including the selling
+//   ,duplication, or modification of any portion is strictly prohibited.
+//
+// Disclaimer:
+//
+//   This VHDL or Verilog source code is intended as a design reference
+//   which illustrates how these types of functions can be implemented.
+//   It is the user's responsibility to verify their design for
+//   consistency and functionality through the use of formal
+//   verification methods.  Terasic provides no warranty regarding the use
+//   or functionality of this code.
+//
+// --------------------------------------------------------------------
+//
+//                     Terasic Technologies Inc
+//                     356 Fu-Shin E. Rd Sec. 1. JhuBei City,
+//                     HsinChu County, Taiwan
+//                     302
+//
+//                     web: http://www.terasic.com/
+//                     email: support@terasic.com
+//
+// --------------------------------------------------------------------
+
+module I2C_AUDIO_Config (	//	Host Side
+					iCLK,
+					iRST_N,
+					//	I2C Side
+					I2C_SCLK,
+					I2C_SDAT,
+					READY
+					 );
+//	Host Side
+input				iCLK;
+input				iRST_N;
+//	I2C Side
+output			I2C_SCLK;
+inout				I2C_SDAT;
+output READY;
+
+//	Internal Registers/Wires
+reg	[15:0]	mI2C_CLK_DIV;
+reg	[23:0]	mI2C_DATA;
+reg				mI2C_CTRL_CLK;
+reg				mI2C_GO;
+wire				mI2C_END;
+wire				mI2C_ACK;
+reg	[15:0]	LUT_DATA;
+reg	[5:0]		LUT_INDEX;
+reg	[3:0]		mSetup_ST;
+reg READY ;
+
+//  Clock Setting
+parameter   CLK_Freq     =   50000000;   //  50  MHz
+parameter   I2C_Freq     =   20000;      //  20  KHz
+//  LUT Data Number
+parameter   LUT_SIZE     =   11;
+//	Audio Data Index
+parameter	Dummy_DATA	=	0;
+parameter	SET_LIN_L	=	1;
+parameter	SET_LIN_R	=	2;
+parameter	SET_HEAD_L	=	3;
+parameter	SET_HEAD_R	=	4;
+parameter	A_PATH_CTRL	=	5;
+parameter	D_PATH_CTRL	=	6;
+parameter	POWER_ON	=	7;
+parameter	SET_FORMAT	=	8;
+parameter	SAMPLE_CTRL	=	9;
+parameter	SET_ACTIVE	=	10;
+//  Audio codec I2C address
+parameter   AUD_I2C_ADDR =   8'h34;
+
+/////////////////////	I2C Control Clock	////////////////////////
+always@(posedge iCLK or negedge iRST_N)
+begin
+	if(!iRST_N)
+	begin
+		mI2C_CTRL_CLK	<=	0;
+		mI2C_CLK_DIV	<=	0;
+	end
+	else
+	begin
+		if( mI2C_CLK_DIV	< (CLK_Freq/I2C_Freq) )
+			mI2C_CLK_DIV	<=	mI2C_CLK_DIV+1;
+		else
+		begin
+			mI2C_CLK_DIV	<=	0;
+			mI2C_CTRL_CLK	<=	~mI2C_CTRL_CLK;
+		end
+	end
+end
+////////////////////////////////////////////////////////////////////
+I2C_Controller 	u0	(	.CLOCK(mI2C_CTRL_CLK),	//	Controller Work Clock
+						.I2C_SCLK(I2C_SCLK),				//	I2C CLOCK
+ 	 	 	 	 	 	.I2C_SDAT(I2C_SDAT),				//	I2C DATA
+						.I2C_DATA(mI2C_DATA),			//	DATA:[SLAVE_ADDR,SUB_ADDR,DATA]
+						.GO(mI2C_GO),						//	GO transfor
+						.END(mI2C_END),					//	END transfor
+						.ACK(mI2C_ACK),					//	ACK
+						.RESET(iRST_N)	);
+////////////////////////////////////////////////////////////////////
+//////////////////////	Config Control	////////////////////////////
+always@(posedge mI2C_CTRL_CLK or negedge iRST_N)
+begin
+	if(!iRST_N)
+	begin
+		READY		<=	0;
+		LUT_INDEX	<=	0;
+		mSetup_ST	<=	0;
+		mI2C_GO		<=	0;
+	end
+	else
+	begin
+		if(LUT_INDEX<LUT_SIZE)
+		begin
+		READY<=0;
+			case(mSetup_ST)
+			0:	begin
+					mI2C_DATA	<=	{AUD_I2C_ADDR,LUT_DATA};
+					mI2C_GO		<=	1;
+					mSetup_ST	<=	1;
+				end
+			1:	begin
+					if(mI2C_END)
+					begin
+						if(!mI2C_ACK)
+						mSetup_ST	<=	2;
+						else
+						mSetup_ST	<=	0;
+						mI2C_GO		<=	0;
+					end
+				end
+			2:	begin
+					LUT_INDEX	<=	LUT_INDEX+1;
+					mSetup_ST	<=	0;
+				end
+			endcase
+		end
+		else
+		begin
+		  READY<=1;
+		end
+	end
+end
+////////////////////////////////////////////////////////////////////
+/////////////////////	Config Data LUT	  //////////////////////////	
+always
+begin
+    case(LUT_INDEX)
+    //  Audio Config Data: 7 bit reg address + 9 bits of data
+    Dummy_DATA  :   LUT_DATA <= 16'h0000;
+    SET_LIN_L   :   LUT_DATA <= 16'h0017;   //R0 LINVOL = 17h (+0.0bB)
+    SET_LIN_R   :   LUT_DATA <= 16'h0217;   //R1 RINVOL = 17h (+0.0bB)
+    SET_HEAD_L  :   LUT_DATA <= 16'h0460;   //R2 LHPVOL = 60h (-43dB)
+    SET_HEAD_R  :   LUT_DATA <= 16'h0660;   //R3 RHPVOL = 60h (-43dB)
+    A_PATH_CTRL :   LUT_DATA <= 16'h08D2;   //R4 DACSEL = 1
+    D_PATH_CTRL :   LUT_DATA <= 16'h0A06;   //R5 DEEMP = 11 (48 KHz)
+    POWER_ON    :   LUT_DATA <= 16'h0C00;   //R6 PWR_CTL = 00h (disable power down)
+    SET_FORMAT  :   LUT_DATA <= 16'h0E02;   //R7 FORMAT=10(I2S), 16 bit
+    SAMPLE_CTRL :   LUT_DATA <= 16'h1002;   //R8 48KHz, Normal mode
+    SET_ACTIVE  :   LUT_DATA <= 16'h1201;   //R9 ACTIVE
+    default     :   LUT_DATA <= 16'h0000;
+    endcase
+end
+////////////////////////////////////////////////////////////////////
+endmodule

--- a/boards/de2_115/I2C_Controller.v
+++ b/boards/de2_115/I2C_Controller.v
@@ -1,0 +1,75 @@
+// --------------------------------------------------------------------
+// Copyright (c) 2005 by Terasic Technologies Inc.
+// --------------------------------------------------------------------
+//
+// Permission:
+//
+//   Terasic grants permission to use and modify this code for use
+//   in synthesis for all Terasic Development Boards and Altrea Development
+//   Kits made by Terasic.  Other use of this code, including the selling
+//   ,duplication, or modification of any portion is strictly prohibited.
+//
+// Disclaimer:
+//
+//   This VHDL or Verilog source code is intended as a design reference
+//   which illustrates how these types of functions can be implemented.
+//   It is the user's responsibility to verify their design for
+//   consistency and functionality through the use of formal
+//   verification methods.  Terasic provides no warranty regarding the use
+//   or functionality of this code.
+//
+// --------------------------------------------------------------------
+//
+//                     Terasic Technologies Inc
+//                     356 Fu-Shin E. Rd Sec. 1. JhuBei City,
+//                     HsinChu County, Taiwan
+//                     302
+//
+//                     web: http://www.terasic.com/
+//                     email: support@terasic.com
+//
+// --------------------------------------------------------------------
+//
+// Major Functions:i2c controller
+//
+// --------------------------------------------------------------------
+//
+// Revision History :
+// --------------------------------------------------------------------
+//   Ver  :| Author            :| Mod. Date :| Changes Made:
+//   V1.0 :| Joe Yang          :| 05/07/10  :|      Initial Revision
+//   V2.0 :| Joe Yang          :| 12/12/16  :|      Initial Revision
+// --------------------------------------------------------------------
+module I2C_Controller (
+	input  CLOCK,
+	input  [23:0]I2C_DATA,
+	input  GO,
+	input  RESET,
+	input  W_R,
+ 	inout  I2C_SDAT,
+	output I2C_SCLK,
+	output END,
+	output ACK
+);
+
+wire SDAO ;
+
+assign I2C_SDAT = SDAO?1'bz :0  ;
+
+I2C_WRITE_WDATA  wrd(
+   .RESET_N  ( RESET),
+	.PT_CK    ( CLOCK),
+	.GO       ( GO   ),
+	.END_OK   ( END  ),
+	.ACK_OK   ( ACK  ),
+	.BYTE_NUM ( 2    ),  //2byte
+	.SDAI     ( I2C_SDAT ),//IN
+	.SDAO     ( SDAO     ),//OUT
+	.SCLO     ( I2C_SCLK ),
+	.SLAVE_ADDRESS( I2C_DATA[23:16] ),
+	.REG_DATA     ( I2C_DATA[15:0]  )
+);
+
+
+
+endmodule

--- a/boards/de2_115/I2C_WRITE_WDATA.v
+++ b/boards/de2_115/I2C_WRITE_WDATA.v
@@ -1,0 +1,138 @@
+// --------------------------------------------------------------------
+// Copyright (c) 2005 by Terasic Technologies Inc.
+// --------------------------------------------------------------------
+//
+// Permission:
+//
+//   Terasic grants permission to use and modify this code for use
+//   in synthesis for all Terasic Development Boards and Altrea Development
+//   Kits made by Terasic.  Other use of this code, including the selling
+//   ,duplication, or modification of any portion is strictly prohibited.
+//
+// Disclaimer:
+//
+//   This VHDL or Verilog source code is intended as a design reference
+//   which illustrates how these types of functions can be implemented.
+//   It is the user's responsibility to verify their design for
+//   consistency and functionality through the use of formal
+//   verification methods.  Terasic provides no warranty regarding the use
+//   or functionality of this code.
+//
+// --------------------------------------------------------------------
+//
+//                     Terasic Technologies Inc
+//                     356 Fu-Shin E. Rd Sec. 1. JhuBei City,
+//                     HsinChu County, Taiwan
+//                     302
+//
+//                     web: http://www.terasic.com/
+//                     email: support@terasic.com
+//
+// --------------------------------------------------------------------
+
+module I2C_WRITE_WDATA  (
+   input  				RESET_N ,
+	input      		  	PT_CK,
+	input      		  	GO,
+	input      [15:0] REG_DATA,
+	input      [7:0] 	SLAVE_ADDRESS,
+	input            	SDAI,
+	output reg       	SDAO,
+	output reg       	SCLO,
+	output reg       	END_OK,
+
+	//--for test
+	output reg [7:0] 	ST ,
+	output reg [7:0] 	CNT,
+	output reg [7:0] 	BYTE,
+	output reg       	ACK_OK,
+   input      [7:0]  BYTE_NUM  // 4 : 4 byte
+);
+
+//===reg/wire
+reg   [8:0]A ;
+reg   [7:0]DELY ;
+
+always @( negedge RESET_N or posedge  PT_CK )begin
+if (!RESET_N  ) ST <=0;
+else
+	  case (ST)
+	    0: begin  //start
+		      SDAO   <=1;
+	         SCLO   <=1;
+	         ACK_OK <=0;
+	         CNT    <=0;
+	         END_OK <=1;
+	         BYTE   <=0;
+	         if (GO) ST  <=30 ; // inital
+		    end
+	    1: begin  //start
+		      ST <=2 ;
+			   { SDAO,  SCLO } <= 2'b01;
+				A <= {SLAVE_ADDRESS ,1'b1 };//WRITE COMMAND
+		    end
+	    2: begin  //start
+		      ST <=3 ;
+			   { SDAO,  SCLO } <= 2'b00;
+		    end
+
+	    3: begin
+		      ST <=4 ;
+			   { SDAO, A } <= { A ,1'b0 };
+		    end
+	    4: begin
+		      ST <=5 ;
+			   SCLO <= 1'b1 ;
+				CNT <= CNT +1 ;
+		    end
+
+	    5: begin
+			   SCLO <= 1'b0 ;
+			   if (CNT==9) begin
+				     if ( BYTE == BYTE_NUM )  ST <= 6 ;
+					  else  begin
+					           CNT <=0 ;
+					           ST <= 2 ;
+					                if ( BYTE ==0 ) begin BYTE <=1  ; A <= {REG_DATA[15:8] ,1'b1 }; end
+					           else if ( BYTE ==1 ) begin BYTE <=2  ; A <= {REG_DATA[7:0] ,1'b1 }; end
+							  end
+					  if (SDAI ) ACK_OK <=1 ;
+				 end
+				 else ST <= 2;
+		    end
+
+	    6: begin          //stop
+		      ST <=7 ;
+			   { SDAO,  SCLO } <= 2'b00;
+         end
+
+	    7: begin          //stop
+		      ST <=8 ;
+			   { SDAO,  SCLO } <= 2'b01;
+         end
+	    8: begin          //stop
+		      ST <=9 ;
+			   { SDAO,  SCLO } <= 2'b11;
+
+         end
+		9:	begin
+		      ST     <= 30;
+				SDAO   <=1;
+	         SCLO   <=1;
+	         CNT    <=0;
+	         END_OK <=1;
+	         BYTE   <=0;
+		     end
+		//--- END ---
+		   30: begin
+            if (!GO) ST  <=31;
+          end
+		   31: begin  //
+		      END_OK<=0;
+				ACK_OK<=0;
+				ST    <=1;
+			end
+	  endcase
+ end
+
+endmodule

--- a/boards/de2_115/board_specific.qsf
+++ b/boards/de2_115/board_specific.qsf
@@ -26,6 +26,8 @@
   set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to HEX7*
 
   set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to VGA_*
+  set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to AUD_*
+  set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to I2C_*
   set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to UART*
   set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to GPIO*
 
@@ -176,6 +178,16 @@
   set_location_assignment PIN_C12  -to VGA_B[5]
   set_location_assignment PIN_D11  -to VGA_B[6]
   set_location_assignment PIN_D12  -to VGA_B[7]
+
+  set_location_assignment PIN_C2   -to AUD_ADCLRCK
+  set_location_assignment PIN_D2   -to AUD_ADCDAT
+  set_location_assignment PIN_F2   -to AUD_BCLK
+  set_location_assignment PIN_E3   -to AUD_DACLRCK
+  set_location_assignment PIN_D1   -to AUD_DACDAT
+  set_location_assignment PIN_E1   -to AUD_XCK
+
+  set_location_assignment PIN_B7   -to I2C_SCLK
+  set_location_assignment PIN_A8   -to I2C_SDAT
 
   set_location_assignment PIN_G14  -to UART_RTS
   set_location_assignment PIN_J13  -to UART_CTS


### PR DESCRIPTION
de1_soc, de1, de2 and de2_115: audio output through onboard codec added.
Support for external PCM5102A has been removed.