### PR TITLE
schoolRISCV with fully associative instruction cache

### DIFF
--- a/labs/5_cpu/5_3_schoolriscv_cache/01_clean.bash
+++ b/labs/5_cpu/5_3_schoolriscv_cache/01_clean.bash
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail  # See the meaning in scripts/README.md
+
+script=$(basename "$0")
+source_script=${script/\.bash/.source_bash}
+dir_source_script=../scripts/steps/$source_script
+
+for i in {1..5}
+do
+    [ -f $dir_source_script ] && break
+    dir_source_script=../$dir_source_script
+done
+
+if ! [ -f $dir_source_script ]; then
+    printf "$script: cannot find \"$source_script\"\n" 1>&2
+    exit 1
+fi
+
+dir_source_script=$(readlink -f $dir_source_script)
+. "$dir_source_script"

--- a/labs/5_cpu/5_3_schoolriscv_cache/02_simulate_rtl.bash
+++ b/labs/5_cpu/5_3_schoolriscv_cache/02_simulate_rtl.bash
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail  # See the meaning in scripts/README.md
+
+script=$(basename "$0")
+source_script=${script/\.bash/.source_bash}
+dir_source_script=../scripts/steps/$source_script
+
+for i in {1..5}
+do
+    [ -f $dir_source_script ] && break
+    dir_source_script=../$dir_source_script
+done
+
+if ! [ -f $dir_source_script ]; then
+    printf "$script: cannot find \"$source_script\"\n" 1>&2
+    exit 1
+fi
+
+dir_source_script=$(readlink -f $dir_source_script)
+. "$dir_source_script"

--- a/labs/5_cpu/5_3_schoolriscv_cache/03_synthesize_for_fpga.bash
+++ b/labs/5_cpu/5_3_schoolriscv_cache/03_synthesize_for_fpga.bash
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail  # See the meaning in scripts/README.md
+
+script=$(basename "$0")
+source_script=${script/\.bash/.source_bash}
+dir_source_script=../scripts/steps/$source_script
+
+for i in {1..5}
+do
+    [ -f $dir_source_script ] && break
+    dir_source_script=../$dir_source_script
+done
+
+if ! [ -f $dir_source_script ]; then
+    printf "$script: cannot find \"$source_script\"\n" 1>&2
+    exit 1
+fi
+
+dir_source_script=$(readlink -f $dir_source_script)
+. "$dir_source_script"

--- a/labs/5_cpu/5_3_schoolriscv_cache/04_configure_fpga.bash
+++ b/labs/5_cpu/5_3_schoolriscv_cache/04_configure_fpga.bash
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail  # See the meaning in scripts/README.md
+
+script=$(basename "$0")
+source_script=${script/\.bash/.source_bash}
+dir_source_script=../scripts/steps/$source_script
+
+for i in {1..5}
+do
+    [ -f $dir_source_script ] && break
+    dir_source_script=../$dir_source_script
+done
+
+if ! [ -f $dir_source_script ]; then
+    printf "$script: cannot find \"$source_script\"\n" 1>&2
+    exit 1
+fi
+
+dir_source_script=$(readlink -f $dir_source_script)
+. "$dir_source_script"

--- a/labs/5_cpu/5_3_schoolriscv_cache/05_run_gui_for_fpga_synthesis.bash
+++ b/labs/5_cpu/5_3_schoolriscv_cache/05_run_gui_for_fpga_synthesis.bash
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail  # See the meaning in scripts/README.md
+
+script=$(basename "$0")
+source_script=${script/\.bash/.source_bash}
+dir_source_script=../scripts/steps/$source_script
+
+for i in {1..5}
+do
+    [ -f $dir_source_script ] && break
+    dir_source_script=../$dir_source_script
+done
+
+if ! [ -f $dir_source_script ]; then
+    printf "$script: cannot find \"$source_script\"\n" 1>&2
+    exit 1
+fi
+
+dir_source_script=$(readlink -f $dir_source_script)
+. "$dir_source_script"

--- a/labs/5_cpu/5_3_schoolriscv_cache/06_choose_another_fpga_board.bash
+++ b/labs/5_cpu/5_3_schoolriscv_cache/06_choose_another_fpga_board.bash
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail  # See the meaning in scripts/README.md
+
+script=$(basename "$0")
+source_script=${script/\.bash/.source_bash}
+dir_source_script=../scripts/steps/$source_script
+
+for i in {1..5}
+do
+    [ -f $dir_source_script ] && break
+    dir_source_script=../$dir_source_script
+done
+
+if ! [ -f $dir_source_script ]; then
+    printf "$script: cannot find \"$source_script\"\n" 1>&2
+    exit 1
+fi
+
+dir_source_script=$(readlink -f $dir_source_script)
+. "$dir_source_script"

--- a/labs/5_cpu/5_3_schoolriscv_cache/07_synthesize_for_asic.bash
+++ b/labs/5_cpu/5_3_schoolriscv_cache/07_synthesize_for_asic.bash
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail  # See the meaning in scripts/README.md
+
+script=$(basename "$0")
+source_script=${script/\.bash/.source_bash}
+dir_source_script=../scripts/steps/$source_script
+
+for i in {1..5}
+do
+    [ -f $dir_source_script ] && break
+    dir_source_script=../$dir_source_script
+done
+
+if ! [ -f $dir_source_script ]; then
+    printf "$script: cannot find \"$source_script\"\n" 1>&2
+    exit 1
+fi
+
+dir_source_script=$(readlink -f $dir_source_script)
+. "$dir_source_script"

--- a/labs/5_cpu/5_3_schoolriscv_cache/08_visualize_asic_synthesis_results_1.bash
+++ b/labs/5_cpu/5_3_schoolriscv_cache/08_visualize_asic_synthesis_results_1.bash
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail  # See the meaning in scripts/README.md
+
+script=$(basename "$0")
+source_script=${script/\.bash/.source_bash}
+dir_source_script=../scripts/steps/$source_script
+
+for i in {1..5}
+do
+    [ -f $dir_source_script ] && break
+    dir_source_script=../$dir_source_script
+done
+
+if ! [ -f $dir_source_script ]; then
+    printf "$script: cannot find \"$source_script\"\n" 1>&2
+    exit 1
+fi
+
+dir_source_script=$(readlink -f $dir_source_script)
+. "$dir_source_script"

--- a/labs/5_cpu/5_3_schoolriscv_cache/09_visualize_asic_synthesis_results_2.bash
+++ b/labs/5_cpu/5_3_schoolriscv_cache/09_visualize_asic_synthesis_results_2.bash
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail  # See the meaning in scripts/README.md
+
+script=$(basename "$0")
+source_script=${script/\.bash/.source_bash}
+dir_source_script=../scripts/steps/$source_script
+
+for i in {1..5}
+do
+    [ -f $dir_source_script ] && break
+    dir_source_script=../$dir_source_script
+done
+
+if ! [ -f $dir_source_script ]; then
+    printf "$script: cannot find \"$source_script\"\n" 1>&2
+    exit 1
+fi
+
+dir_source_script=$(readlink -f $dir_source_script)
+. "$dir_source_script"

--- a/labs/5_cpu/5_3_schoolriscv_cache/10_run_instruction_set_simulator.bash
+++ b/labs/5_cpu/5_3_schoolriscv_cache/10_run_instruction_set_simulator.bash
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail  # See the meaning in scripts/README.md
+
+script=$(basename "$0")
+source_script=${script/\.bash/.source_bash}
+dir_source_script=../scripts/steps/$source_script
+
+for i in {1..5}
+do
+    [ -f $dir_source_script ] && break
+    dir_source_script=../$dir_source_script
+done
+
+if ! [ -f $dir_source_script ]; then
+    printf "$script: cannot find \"$source_script\"\n" 1>&2
+    exit 1
+fi
+
+dir_source_script=$(readlink -f $dir_source_script)
+. "$dir_source_script"

--- a/labs/5_cpu/5_3_schoolriscv_cache/asic_config.tcl
+++ b/labs/5_cpu/5_3_schoolriscv_cache/asic_config.tcl
@@ -1,0 +1,15 @@
+# User config
+
+set ::env(DESIGN_NAME) asic_top
+set ::env(VERILOG_FILES) [glob $::env(DESIGN_DIR)/src/*.{v,sv}]
+
+set ::env(CLOCK_PORT) "clk"
+
+set ::env(FP_SIZING) "absolute"
+set ::env(DIE_AREA) {0 0 500 500}
+
+set filename $::env(DESIGN_DIR)/$::env(PDK)_$::env(STD_CELL_LIBRARY)_config.tcl
+
+if { [file exists $filename] == 1} {
+  source $filename
+}

--- a/labs/5_cpu/5_3_schoolriscv_cache/asic_top.sv
+++ b/labs/5_cpu/5_3_schoolriscv_cache/asic_top.sv
@@ -1,0 +1,61 @@
+`include "config.svh"
+
+module asic_top
+# (
+    parameter clk_mhz = 50,
+              w_key   = 4,
+              w_sw    = 8,
+              w_led   = 8,
+              w_digit = 8,
+              w_gpio  = 0
+)
+(
+    input                        clk,
+    input                        slow_clk,
+    input                        rst,
+
+    // Keys, switches, LEDs
+
+    input        [w_key   - 1:0] key,
+    input        [w_sw    - 1:0] sw,
+    output logic [w_led   - 1:0] led,
+
+    // A dynamic seven-segment display
+
+    output logic [          7:0] abcdefgh,
+    output logic [w_digit - 1:0] digit
+);
+
+    top
+    # (
+        .clk_mhz   ( clk_mhz  ),
+        .w_key     ( w_key    ),
+        .w_sw      ( w_sw     ),
+        .w_led     ( w_led    ),
+        .w_digit   ( w_digit  ),
+        .w_gpio    ( w_gpio   )
+    )
+    i_top
+    (
+        .clk       ( clk      ),
+        .slow_clk  ( slow_clk ),
+        .rst       ( rst      ),
+        .key       ( key      ),
+        .sw        ( sw       ),
+        .led       ( led      ),
+        .abcdefgh  ( abcdefgh ),
+        .digit     ( digit    ),
+
+        .vsync     (          ),
+        .hsync     (          ),
+        .red       (          ),
+        .green     (          ),
+        .blue      (          ),
+        .uart_rx   (          ),
+        .uart_tx   (          ),
+        .mic       (          ),
+        .sound     (          ),
+        .gpio      (          )
+    );
+
+endmodule

--- a/labs/5_cpu/5_3_schoolriscv_cache/gtkwave.tcl
+++ b/labs/5_cpu/5_3_schoolriscv_cache/gtkwave.tcl
@@ -1,0 +1,21 @@
+# gtkwave::loadFile "dump.vcd"
+
+set all_signals [list]
+
+lappend all_signals tb.clk
+lappend all_signals tb.rst
+lappend all_signals tb.soc.cpu.pc
+lappend all_signals tb.imAddr
+lappend all_signals tb.imData
+lappend all_signals tb.regAddr
+lappend all_signals tb.regData
+lappend all_signals tb.soc.cycleCnt_o
+
+set num_added [ gtkwave::addSignalsFromList $all_signals ]
+
+gtkwave::/Time/Zoom/Zoom_Full
+
+# switch performance counter data format to "Decimal"
+gtkwave::/Edit/Highlight_Regexp "cycleCnt_o"
+gtkwave::/Edit/Data_Format/Decimal
+gtkwave::/Edit/UnHighlight_All

--- a/labs/5_cpu/5_3_schoolriscv_cache/instruction_rom.sv
+++ b/labs/5_cpu/5_3_schoolriscv_cache/instruction_rom.sv
@@ -1,0 +1,26 @@
+//
+//  schoolRISCV - small RISC-V CPU
+//
+//  Originally based on Sarah L. Harris MIPS CPU
+//  & schoolMIPS project.
+//
+//  Copyright (c) 2017-2020 Stanislav Zhelnio & Aleksandr Romanov.
+//
+//  Modified in 2024 by Yuri Panchul & Mike Kuskov
+//  for systemverilog-homework project.
+//
+
+module instruction_rom
+#(
+    parameter SIZE = 64
+)
+(
+    input  [31:0] a,
+    output [31:0] rd
+);
+    logic [31:0] rom [0:SIZE - 1];
+    assign rd = rom [a];
+
+    initial $readmemh ("program.hex", rom);
+
+endmodule

--- a/labs/5_cpu/5_3_schoolriscv_cache/lab_top.sv
+++ b/labs/5_cpu/5_3_schoolriscv_cache/lab_top.sv
@@ -1,0 +1,133 @@
+`include "config.svh"
+
+module lab_top
+# (
+    parameter  clk_mhz       = 50,
+               w_key         = 4,
+               w_sw          = 8,
+               w_led         = 8,
+               w_digit       = 8,
+               w_gpio        = 100,
+
+               screen_width  = 640,
+               screen_height = 480,
+
+               w_red         = 4,
+               w_green       = 4,
+               w_blue        = 4,
+
+               w_x           = $clog2 ( screen_width  ),
+               w_y           = $clog2 ( screen_height )
+)
+(
+    input                        clk,
+    input                        slow_clk,
+    input                        rst,
+
+    // Keys, switches, LEDs
+
+    input        [w_key   - 1:0] key,
+    input        [w_sw    - 1:0] sw,
+    output logic [w_led   - 1:0] led,
+
+    // A dynamic seven-segment display
+
+    output logic [          7:0] abcdefgh,
+    output logic [w_digit - 1:0] digit,
+
+    // Graphics
+
+    input        [w_x     - 1:0] x,
+    input        [w_y     - 1:0] y,
+
+    output logic [w_red   - 1:0] red,
+    output logic [w_green - 1:0] green,
+    output logic [w_blue  - 1:0] blue,
+
+    // Microphone, sound output and UART
+
+    input        [         23:0] mic,
+    output       [         15:0] sound,
+
+    input                        uart_rx,
+    output                       uart_tx,
+
+    // General-purpose Input/Output
+
+    inout        [w_gpio  - 1:0] gpio
+);
+
+    //------------------------------------------------------------------------
+
+       assign led        = '0;
+    // assign abcdefgh   = '0;
+    // assign digit      = '0;
+       assign red        = '0;
+       assign green      = '0;
+       assign blue       = '0;
+       assign sound      = '0;
+       assign uart_tx    = '1;
+
+    //------------------------------------------------------------------------
+
+    wire  [31:0] imAddr;        // instruction memory address
+    wire  [31:0] imData;        // instruction memory data
+
+    logic [ 4:0] regAddr;       // debug access reg address
+    wire  [31:0] regData;       // debug access reg data
+    
+    wire  [31:0] cycleCntPerf;  // clk counter for evaluation program time execution
+
+    sr_soc # (
+        .CACHE_EN (0)           // 1 - enable cache, 0 - disable (block cl_hit signal in the sr_icache module)
+    )
+    soc
+    (
+        .clk        ( clk          ),
+        .rst        ( rst          ),
+
+        .soc_addr_o ( imAddr       ),
+        .soc_data_i ( imData       ),
+
+        .regAddr    ( regAddr      ),
+        .regData    ( regData      ),
+
+        .cycleCnt_o ( cycleCntPerf )
+    );
+
+    instruction_rom # (
+        .SIZE (1024)
+    )
+    rom
+    (
+        .a       ( imAddr  ),
+        .rd      ( imData  )
+    );
+
+    assign regAddr = 5'd10;  // a0 address line of the cpu register file
+
+    //------------------------------------------------------------------------
+
+    localparam w_number = w_digit * 4;
+
+    wire [w_number - 1:0] number
+        = w_number' ( cycleCntPerf );
+
+    seven_segment_display
+    # (
+        .w_digit  ( w_digit  ),
+        .clk_mhz  ( clk_mhz  )
+    )
+    display
+    (
+        .clk      ( clk      ),
+        .rst      ( rst      ),
+
+        .number   ( number   ),
+        .dots     ( '0       ),
+
+        .abcdefgh ( abcdefgh ),
+        .digit    ( digit    )
+    );
+
+endmodule

--- a/labs/5_cpu/5_3_schoolriscv_cache/perf_cycle_counter.sv
+++ b/labs/5_cpu/5_3_schoolriscv_cache/perf_cycle_counter.sv
@@ -1,0 +1,29 @@
+/*
+ * schoolRISCV - small RISC-V CPU
+ *
+ * originally based on Sarah L. Harris MIPS CPU
+ *                   & schoolMIPS project
+ *
+ * Copyright(c) 2017-2020 Stanislav Zhelnio
+ *                        Aleksandr Romanov
+ */
+
+// performance counter
+module perf_cycle_counter (
+    input               clk,
+    input               rst,
+    input               en_i,
+    input               clear_i,
+    output logic [31:0] cycleCnt_o
+);
+
+wire [31:0] cycleCnt_next;
+
+assign cycleCnt_next = clear_i ? 32'd0 : (en_i ? cycleCnt_o + 32'd1 : cycleCnt_o);
+
+// cycle counter
+always_ff @(posedge clk)
+    if (rst) cycleCnt_o <= 32'd0;
+    else     cycleCnt_o <= cycleCnt_next;
+
+endmodule

--- a/labs/5_cpu/5_3_schoolriscv_cache/program.s
+++ b/labs/5_cpu/5_3_schoolriscv_cache/program.s
@@ -1,0 +1,66 @@
+# li pseudo-instruction
+
+        li      t0, 0x2F          ## iterations count
+        li      t2, 0x123         ## li is a pseudo command
+        li      t3, 0x12345678    ## there li is two real instructions: lui and addi
+        li      t4, 0x12345000    ## two real instructions: lui and addi
+        li      t5, -0x123
+
+# RISC-V fibonacci program
+#
+# Stanislav Zhelnio, 2020
+# Amended by Yuri Panchul, 2024
+
+init:
+
+        li       t1, 0x1         ## iteration decrement value
+
+        li       a1, 1
+        li       a7, 0xffff0020  ## memory-mapped I/O: start/stop cycle counter port address
+                                 ## RARS MMIO addresses is 0xffff0000 - 0xffffffe0
+                                 ## two real instructions
+        sw       a1, 0(a7)       ## cycle_cnt start
+
+fibonacci:
+
+        mv      a0, zero
+        li      t2, 1
+
+loop:   add     t3, a0, t2
+        mv      a0, t2
+        mv      t2, t3
+        sub     t0, t0, t1
+        bnez    t0, loop
+
+        sw       zero, 0(a7)     ## cycle_cnt stop
+        nop                      ## nop for program align; mem_ctrl prefetch take four commands time after time
+finish: beqz     zero, finish
+
+# RISC-V factorial program
+# Uncomment it when necessary
+
+#init:
+#        li       t1, 0x1         ## iteration decrement value
+
+#        li       a1, 1
+#        li       a7, 0xffff0020  ## memory-mapped I/O: start/stop cycle counter port address
+                                 ## RARS MMIO addresses is 0xffff0000 - 0xffffffe0
+                                 ## two real instructions
+#        sw       a1, 0(a7)       ## cycle_cnt start
+
+#factorial:
+
+#        li      a0, 1
+#        li      t2, 2
+
+#loop:   mul     a0, a0, t2       ## CPU support for the mul instruction required
+#        addi    t2, t2, 1
+#        sub     t0, t0, t1
+#        bnez    t0, loop
+
+#        sw       zero, 0(a7)     ## cycle_cnt stop
+#        nop                      ## nop for program align; mem_ctrl prefetch take four commands time after time
+#        nop
+#        nop
+#        nop
+#finish: beqz     zero, finish

--- a/labs/5_cpu/5_3_schoolriscv_cache/register_with_we.sv
+++ b/labs/5_cpu/5_3_schoolriscv_cache/register_with_we.sv
@@ -1,0 +1,27 @@
+//
+//  schoolRISCV - small RISC-V CPU
+//
+//  Originally based on Sarah L. Harris MIPS CPU
+//  & schoolMIPS project.
+//
+//  Copyright (c) 2017-2020 Stanislav Zhelnio & Aleksandr Romanov.
+//
+//  Modified in 2024 by Alexander Kirichenko
+//  for systemverilog-homework project.
+//
+
+module register_with_we
+(
+    input             clk,
+    input             rst,
+    input             we,
+    input      [31:0] d,
+    output reg [31:0] q
+);
+    always_ff @ (posedge clk)
+        if (rst)
+            q <= '0;
+        else
+            if (we) q <= d;
+
+endmodule

--- a/labs/5_cpu/5_3_schoolriscv_cache/sr_alu.sv
+++ b/labs/5_cpu/5_3_schoolriscv_cache/sr_alu.sv
@@ -1,0 +1,36 @@
+//
+//  schoolRISCV - small RISC-V CPU
+//
+//  Originally based on Sarah L. Harris MIPS CPU
+//  & schoolMIPS project.
+//
+//  Copyright (c) 2017-2020 Stanislav Zhelnio & Aleksandr Romanov.
+//
+//  Modified in 2024 by Yuri Panchul & Mike Kuskov
+//  for systemverilog-homework project.
+//
+
+`include "sr_cpu.svh"
+
+module sr_alu
+(
+    input        [31:0] srcA,
+    input        [31:0] srcB,
+    input        [ 2:0] oper,
+    output              zero,
+    output logic [31:0] result
+);
+
+    always_comb
+        case (oper)
+            default   : result =  srcA +  srcB;
+            `ALU_ADD  : result =  srcA +  srcB;
+            `ALU_OR   : result =  srcA |  srcB;
+            `ALU_SRL  : result =  srcA >> srcB [4:0];
+            `ALU_SLTU : result = (srcA <  srcB) ? 32'd1 : 32'd0;
+            `ALU_SUB  : result =  srcA -  srcB;
+        endcase
+
+    assign zero = (result == '0);
+
+endmodule

--- a/labs/5_cpu/5_3_schoolriscv_cache/sr_control.sv
+++ b/labs/5_cpu/5_3_schoolriscv_cache/sr_control.sv
@@ -1,0 +1,59 @@
+//
+//  schoolRISCV - small RISC-V CPU
+//
+//  Originally based on Sarah L. Harris MIPS CPU
+//  & schoolMIPS project.
+//
+//  Copyright (c) 2017-2020 Stanislav Zhelnio & Aleksandr Romanov.
+//
+//  Modified in 2024 by Yuri Panchul & Mike Kuskov
+//  for systemverilog-homework project.
+//
+
+`include "sr_cpu.svh"
+
+module sr_control
+(
+    input        [ 6:0] cmdOp,
+    input        [ 2:0] cmdF3,
+    input        [ 6:0] cmdF7,
+    input               aluZero,
+    output              pcSrc,
+    output logic        regWrite,
+    output logic [1:0]  aluSrc,
+    output logic        wdSrc,
+    output logic        memWrite,
+    output logic [ 2:0] aluControl
+);
+    logic          branch;
+    logic          condZero;
+    assign pcSrc = branch & (aluZero == condZero);
+
+    always_comb
+    begin
+        branch      = 1'b0;
+        condZero    = 1'b0;
+        regWrite    = 1'b0;
+        aluSrc      = `SRC_B_RD2;
+        wdSrc       = 1'b0;
+        memWrite    = 1'b0;
+        aluControl  = `ALU_ADD;
+
+        casez ({ cmdF7, cmdF3, cmdOp })
+            { `RVF7_ADD,  `RVF3_ADD,  `RVOP_ADD  } : begin regWrite = 1'b1; aluControl = `ALU_ADD;  end
+            { `RVF7_OR,   `RVF3_OR,   `RVOP_OR   } : begin regWrite = 1'b1; aluControl = `ALU_OR;   end
+            { `RVF7_SRL,  `RVF3_SRL,  `RVOP_SRL  } : begin regWrite = 1'b1; aluControl = `ALU_SRL;  end
+            { `RVF7_SLTU, `RVF3_SLTU, `RVOP_SLTU } : begin regWrite = 1'b1; aluControl = `ALU_SLTU; end
+            { `RVF7_SUB,  `RVF3_SUB,  `RVOP_SUB  } : begin regWrite = 1'b1; aluControl = `ALU_SUB;  end
+
+            { `RVF7_ANY,  `RVF3_ADDI, `RVOP_ADDI } : begin regWrite = 1'b1; aluSrc = `SRC_B_IMM_I; aluControl = `ALU_ADD; end
+            { `RVF7_ANY,  `RVF3_ANY,  `RVOP_LUI  } : begin regWrite = 1'b1; wdSrc  = 1'b1; end
+
+            { `RVF7_ANY,  `RVF3_BEQ,  `RVOP_BEQ  } : begin branch = 1'b1; condZero = 1'b1; aluControl = `ALU_SUB; end
+            { `RVF7_ANY,  `RVF3_BNE,  `RVOP_BNE  } : begin branch = 1'b1; aluControl = `ALU_SUB; end
+
+            { `RVF7_ANY,  `RVF3_SW,   `RVOP_SW   } : begin memWrite = 1'b1; aluSrc = `SRC_B_IMM_S; aluControl = `ALU_ADD; end
+        endcase
+    end
+
+endmodule

--- a/labs/5_cpu/5_3_schoolriscv_cache/sr_cpu.sv
+++ b/labs/5_cpu/5_3_schoolriscv_cache/sr_cpu.sv
@@ -1,0 +1,157 @@
+//
+//  schoolRISCV - small RISC-V CPU
+//
+//  Originally based on Sarah L. Harris MIPS CPU
+//  & schoolMIPS project.
+//
+//  Copyright (c) 2017-2020 Stanislav Zhelnio & Aleksandr Romanov.
+//
+//  Modified in 2024 by Yuri Panchul & Mike Kuskov
+//  for systemverilog-homework project.
+//
+
+`include "sr_cpu.svh"
+
+module sr_cpu
+(
+    input           clk,      // clock
+    input           rst,      // reset
+
+    output          im_req,   // Instruction memory request
+    output  [31:0]  imAddr,   // instruction memory address
+    input   [31:0]  imData,   // instruction memory data
+    input           im_drdy,  // instruction memory data ready
+
+    input   [ 4:0]  regAddr,  // debug access reg address
+    output  [31:0]  regData,  // debug access reg data
+    output  [31:0]  memAddr,  // data memory address
+    output  [31:0]  memData,  // data memory data
+    output          memWrite  // data memory write request
+);
+    // control wires
+
+    wire        aluZero;
+    wire        pcSrc;
+    wire        regWrite;
+    wire        rfUpd;
+    wire  [1:0] aluSrc;
+    wire        wdSrc;
+    wire  [2:0] aluControl;
+
+    // instruction decode wires
+
+    wire [ 6:0] cmdOp;
+    wire [ 4:0] rd;
+    wire [ 2:0] cmdF3;
+    wire [ 4:0] rs1;
+    wire [ 4:0] rs2;
+    wire [ 6:0] cmdF7;
+    wire [31:0] immI;
+    wire [31:0] immS;
+    wire [31:0] immB;
+    wire [31:0] immU;
+
+    // program counter
+
+    wire [31:0] pc;
+    wire [31:0] pcBranch = pc + immB;
+    wire [31:0] pcPlus4  = pc + 32'd4;
+    wire [31:0] pcNext   = pcSrc ? pcBranch : pcPlus4;
+
+    register_with_we r_pc (clk, rst, im_drdy, pcNext, pc);
+
+    // program memory access
+    assign imAddr = im_drdy ? (pcNext >> 2) : (pc >> 2);
+    assign im_req = im_drdy;
+
+    wire [31:0] instr = imData;
+
+    // instruction decode
+
+    sr_decode id
+    (
+        .instr      ( instr       ),
+        .cmdOp      ( cmdOp       ),
+        .rd         ( rd          ),
+        .cmdF3      ( cmdF3       ),
+        .rs1        ( rs1         ),
+        .rs2        ( rs2         ),
+        .cmdF7      ( cmdF7       ),
+        .immI       ( immI        ),
+        .immS       ( immS        ),
+        .immB       ( immB        ),
+        .immU       ( immU        )
+    );
+
+    // register file
+
+    wire [31:0] rd0;
+    wire [31:0] rd1;
+    wire [31:0] rd2;
+    wire [31:0] wd3;
+
+    assign rfUpd = regWrite & im_drdy;
+
+    sr_register_file rf
+    (
+        .clk        ( clk         ),
+        .a0         ( regAddr     ),
+        .a1         ( rs1         ),
+        .a2         ( rs2         ),
+        .a3         ( rd          ),
+        .rd0        ( rd0         ),
+        .rd1        ( rd1         ),
+        .rd2        ( rd2         ),
+        .wd3        ( wd3         ),
+        .we3        ( rfUpd       )
+    );
+
+    // alu
+
+    logic [31:0] srcB;
+    wire  [31:0] aluResult;
+
+    always_comb
+        case (aluSrc)
+            `SRC_B_IMM_I: srcB = immI;
+            `SRC_B_IMM_S: srcB = immS;
+            default:      srcB = rd2;
+        endcase
+
+    sr_alu alu
+    (
+        .srcA       ( rd1         ),
+        .srcB       ( srcB        ),
+        .oper       ( aluControl  ),
+        .zero       ( aluZero     ),
+        .result     ( aluResult   )
+    );
+
+    assign wd3 = wdSrc ? immU : aluResult;
+
+    // control
+
+    sr_control sm_control
+    (
+        .cmdOp      ( cmdOp       ),
+        .cmdF3      ( cmdF3       ),
+        .cmdF7      ( cmdF7       ),
+        .aluZero    ( aluZero     ),
+        .pcSrc      ( pcSrc       ),
+        .regWrite   ( regWrite    ),
+        .aluSrc     ( aluSrc      ),
+        .wdSrc      ( wdSrc       ),
+        .memWrite   ( memWrite    ),
+        .aluControl ( aluControl  )
+    );
+
+    // debug register access
+
+    assign regData = (regAddr != '0) ? rd0 : pc;
+
+    // access to data memory
+
+    assign memAddr = aluResult;
+    assign memData = rd2;
+
+endmodule

--- a/labs/5_cpu/5_3_schoolriscv_cache/sr_cpu.svh
+++ b/labs/5_cpu/5_3_schoolriscv_cache/sr_cpu.svh
@@ -1,0 +1,64 @@
+//
+//  schoolRISCV - small RISC-V CPU
+//
+//  Originally based on Sarah L. Harris MIPS CPU
+//  & schoolMIPS project.
+//
+//  Copyright (c) 2017-2020 Stanislav Zhelnio & Aleksandr Romanov.
+//
+//  Modified in 2024 by Yuri Panchul & Mike Kuskov
+//  for systemverilog-homework project.
+//
+
+`ifndef SR_CPU_SVH
+`define SR_CPU_SVH
+
+// ALU commands
+
+`define ALU_ADD     3'b000
+`define ALU_OR      3'b001
+`define ALU_SRL     3'b010
+`define ALU_SLTU    3'b011
+`define ALU_SUB     3'b100
+
+// ALU source B control
+`define SRC_B_RD2   2'b00
+`define SRC_B_IMM_I 2'b01
+`define SRC_B_IMM_S 2'b10
+
+// Instruction opcode
+
+`define RVOP_ADDI   7'b0010011
+`define RVOP_BEQ    7'b1100011
+`define RVOP_LUI    7'b0110111
+`define RVOP_BNE    7'b1100011
+`define RVOP_ADD    7'b0110011
+`define RVOP_OR     7'b0110011
+`define RVOP_SRL    7'b0110011
+`define RVOP_SLTU   7'b0110011
+`define RVOP_SUB    7'b0110011
+`define RVOP_SW     7'b0100011
+
+// Instruction funct3
+
+`define RVF3_ADDI   3'b000
+`define RVF3_BEQ    3'b000
+`define RVF3_BNE    3'b001
+`define RVF3_ADD    3'b000
+`define RVF3_OR     3'b110
+`define RVF3_SRL    3'b101
+`define RVF3_SLTU   3'b011
+`define RVF3_SUB    3'b000
+`define RVF3_SW     3'b010
+`define RVF3_ANY    3'b???
+
+// Instruction funct7
+
+`define RVF7_ADD    7'b0000000
+`define RVF7_OR     7'b0000000
+`define RVF7_SRL    7'b0000000
+`define RVF7_SLTU   7'b0000000
+`define RVF7_SUB    7'b0100000
+`define RVF7_ANY    7'b???????
+
+`endif  // `ifndef SR_CPU_SVH

--- a/labs/5_cpu/5_3_schoolriscv_cache/sr_decode.sv
+++ b/labs/5_cpu/5_3_schoolriscv_cache/sr_decode.sv
@@ -1,0 +1,72 @@
+//
+//  schoolRISCV - small RISC-V CPU
+//
+//  Originally based on Sarah L. Harris MIPS CPU
+//  & schoolMIPS project.
+//
+//  Copyright (c) 2017-2020 Stanislav Zhelnio & Aleksandr Romanov.
+//
+//  Modified in 2024 by Yuri Panchul & Mike Kuskov
+//  for systemverilog-homework project.
+//
+
+`include "sr_cpu.svh"
+
+module sr_decode
+(
+    input        [31:0] instr,
+    output       [ 6:0] cmdOp,
+    output       [ 4:0] rd,
+    output       [ 2:0] cmdF3,
+    output       [ 4:0] rs1,
+    output       [ 4:0] rs2,
+    output       [ 6:0] cmdF7,
+    output logic [31:0] immI,
+    output logic [31:0] immS,
+    output logic [31:0] immB,
+    output logic [31:0] immU
+);
+    assign cmdOp = instr [ 6: 0];
+    assign rd    = instr [11: 7];
+    assign cmdF3 = instr [14:12];
+    assign rs1   = instr [19:15];
+    assign rs2   = instr [24:20];
+    assign cmdF7 = instr [31:25];
+
+    // I-type
+
+    always_comb
+    begin
+        immI [10: 0] = instr [30:20];
+        immI [31:11] = { 21 { instr [31] } };
+    end
+
+    // S-type
+    
+    always_comb
+    begin
+        immS[ 4: 0] = instr[11: 7];
+        immS[10: 5] = instr[30:25];
+        immS[31:11] = { 21 {instr[31]} };
+    end
+    
+    // B-type
+
+    always_comb
+    begin
+        immB [    0] = 1'b0;
+        immB [ 4: 1] = instr [11:8];
+        immB [10: 5] = instr [30:25];
+        immB [   11] = instr [7];
+        immB [31:12] = { 20 { instr [31] } };
+    end
+
+    // U-type
+
+    always_comb
+    begin
+        immU [11: 0] = 12'b0;
+        immU [31:12] = instr [31:12];
+    end
+
+endmodule

--- a/labs/5_cpu/5_3_schoolriscv_cache/sr_icache.sv
+++ b/labs/5_cpu/5_3_schoolriscv_cache/sr_icache.sv
@@ -1,0 +1,164 @@
+/*
+ * schoolRISCV - small RISC-V CPU
+ *
+ * originally based on Sarah L. Harris MIPS CPU
+ *                   & schoolMIPS project
+ *
+ * Copyright(c) 2017-2020 Stanislav Zhelnio
+ *                        Aleksandr Romanov
+ */
+
+// Fully associative instruction cache
+
+ module sr_icache
+ # (
+    parameter bit CACHE_EN = 1'b0
+ )
+ (
+    input  logic          clk,         // clock
+    input  logic          rst,         // reset
+    input  logic          imem_req_i,  // Memory request
+    input  logic  [31:0]  imAddr,      // instruction memory address
+    output logic  [31:0]  imData,      // instruction memory data
+    output logic          im_drdy,
+    output logic  [31:0]  ext_addr_o,
+    output logic          ext_req_o,
+    input  logic          ext_rsp_i,
+    input  logic  [127:0] ext_data_i
+);
+
+localparam NWAYS = 4;
+localparam LINE_SIZE = 128;
+localparam TAG_WIDTH  = 32 - $clog2(LINE_SIZE/32);
+
+logic     [NWAYS -1:0] cache_way_en      ;
+logic [LINE_SIZE -1:0] cache_data_ff     [NWAYS -1:0];
+logic [TAG_WIDTH -1:0] cache_tag_ff      [NWAYS -1:0];
+logic   [2*NWAYS -1:0] cache_state_ff    ;
+logic   [2*NWAYS -1:0] cache_state_next  ;
+logic                  cache_state_en    ;
+logic    [NWAYS -1:0]  plru_set          ;
+logic    [NWAYS -1:0]  cache_plru        ;
+logic    [NWAYS -1:0]  cache_valid       ;
+logic    [NWAYS -1:0]  cache_plru_new    ;
+logic    [NWAYS -1:0]  cache_valid_new   ;
+logic    [NWAYS -1:0]  cache_evict       ;
+
+
+logic [31:0]           req_addr_ff;
+logic                  l1i_req_val_ff;
+
+logic [TAG_WIDTH -1:0] in_tag;
+logic            [1:0] cl_offs;
+logic [TAG_WIDTH -1:0] in_tag_ff;
+logic            [1:0] cl_offs_ff;
+logic                  cl_hit;
+logic                  cl_hit_ff;
+logic [31 :0] hit_data;
+logic [31 :0] rsp_data_next;
+logic [31 :0] rsp_data_ff;
+logic [NWAYS     -1:0] cl_hit_vec;
+
+logic cl_refill_ff;
+
+genvar way_idx;
+
+  // Latch input data;
+  always_ff @(posedge clk)
+    if (imem_req_i)
+      req_addr_ff <= imAddr;
+
+  always_ff @(posedge clk)
+    if (rst)
+      l1i_req_val_ff <= '0;
+    else
+      l1i_req_val_ff <= imem_req_i;
+
+  assign in_tag = imem_req_i ? imAddr[31 -:TAG_WIDTH] : req_addr_ff[31 -:TAG_WIDTH];
+
+  assign cl_offs = imem_req_i ? imAddr[1:0] :req_addr_ff[1:0];
+
+  // Hit/Miss detection and data bypass interface
+  always_comb begin
+    for (integer idx = 0 ; idx < NWAYS; idx = idx + 1)
+      cl_hit_vec[idx] = (in_tag == cache_tag_ff[idx]) & cache_state_ff[idx]; // cache_state_ff[NWAYS-1:0] are valid bits
+                                                                             // cache_state_ff[NWAYS+:NWAYS] are used bits
+  end
+
+  assign cl_hit = (|cl_hit_vec) & CACHE_EN;
+
+  always_comb begin
+    hit_data    = '0;
+    for (integer idx = 0 ; idx < NWAYS; idx = idx + 1)
+      hit_data    |= {32{ cl_hit_vec[idx]}} & cache_data_ff[idx][32*cl_offs +:32];
+  end
+
+  assign rsp_data_next = cl_hit ? hit_data : ext_data_i[32*cl_offs +:32];
+  always_ff @(posedge clk)
+    if (cl_hit | ext_rsp_i)
+      rsp_data_ff <= rsp_data_next;
+
+  assign im_drdy = cl_hit_ff | cl_refill_ff;
+  assign imData  = rsp_data_ff;
+
+  // Memory interface
+  assign ext_req_o  = ~cl_hit_ff & l1i_req_val_ff;
+  assign ext_addr_o = {req_addr_ff[31-:TAG_WIDTH], 2'b0};
+
+  always_ff @(posedge clk)
+    if(rst)  begin
+      cl_hit_ff    <= 0;
+      cl_refill_ff <= 0;
+    end else begin
+      cl_hit_ff    <= cl_hit;
+      cl_refill_ff <= ext_rsp_i;
+    end
+
+  // Refill logic
+  assign cache_evict[0] = (NWAYS==1) ? '1 : ( &(cache_valid) ? ~cache_plru[0] : ~cache_valid[0]); // if cache is full, check used bit
+
+  generate
+    for (way_idx = 1; way_idx < NWAYS; way_idx = way_idx + 1) begin : g_vict
+      assign cache_evict[way_idx] = &(cache_valid) ? (~cache_plru[way_idx] & &(cache_plru[way_idx -1 : 0])) // if [way_idx] used bit is low
+                                                                                                           // and other used bits are high
+                                                                                                           // then way_idx bit of cache_evict is high
+                                          : (~cache_valid[way_idx] & &(cache_valid[way_idx -1 : 0])); // cache_evict logic for valid bits
+    end : g_vict
+  endgenerate
+
+  assign cache_plru       = cache_state_ff[NWAYS+:NWAYS]; // used bits
+  assign cache_valid      = cache_state_ff[NWAYS-1:0];    // valid bits
+
+  assign cache_state_en   = (cl_hit & l1i_req_val_ff ) | ext_rsp_i; // if cpu mem request and cache hit, or memory response
+                                                                    // update used and valid bits
+  assign cache_valid_new  = (cache_valid | ( cache_evict & ~{NWAYS{cl_hit}})); // update valid bits for evicting cache line
+  assign plru_set         = (cl_hit ? cl_hit_vec : cache_evict);    // if hit cache, mark hit cache lines as used,
+                                                                    // else mark evicted cache lines as used
+  assign cache_plru_new   = &(cache_plru | plru_set) ? plru_set                  // if all old used bits aren't equal new bits, take new
+                                                      : (cache_plru | plru_set); // else, merge old one and new
+
+  // used and valid bits register
+  assign cache_state_next = {cache_plru_new, cache_valid_new};
+
+  always_ff @(posedge clk)
+    if(rst)
+      cache_state_ff <= '0;
+    else if (cache_state_en)
+      cache_state_ff <= cache_state_next;
+
+  assign cache_way_en  = cache_evict & {NWAYS{ext_rsp_i}}; // enable update for evicted lines
+
+  // tag and data memory
+  generate
+    for (way_idx = 0; way_idx < NWAYS; way_idx = way_idx + 1) begin : g_cache_memories
+      always_ff @(posedge clk)
+        if (cache_way_en[way_idx]) begin
+          cache_data_ff[way_idx] <= ext_data_i;
+          cache_tag_ff[way_idx]  <= in_tag;
+        end
+
+    end : g_cache_memories
+  endgenerate
+
+
+endmodule

--- a/labs/5_cpu/5_3_schoolriscv_cache/sr_mem.sv
+++ b/labs/5_cpu/5_3_schoolriscv_cache/sr_mem.sv
@@ -1,0 +1,75 @@
+/*
+ * schoolRISCV - small RISC-V CPU
+ *
+ * originally based on Sarah L. Harris MIPS CPU
+ *                   & schoolMIPS project
+ *
+ * Copyright(c) 2017-2020 Stanislav Zhelnio
+ *                        Aleksandr Romanov
+ */
+
+  module sr_mem (
+  input logic clk,
+  input logic rst,
+
+  input   logic  [31:0]  ext_addr_i,
+  input   logic          ext_req_i,
+  output  logic          ext_rsp_o,
+  output  logic  [127:0] ext_data_o,
+
+  input  logic   [31:0] rom_data_i,
+  output logic   [31:0] rom_addr_o
+  );
+
+  localparam DEPTH        = 1024;
+  localparam AWIDTH       = 10;
+  localparam RD_NUM       = 128/32;
+  localparam MEM_DELAY    = 10;
+
+
+  logic [AWIDTH -1:0]        ram_addr_ff;
+  logic [31:0]               ram_dout;
+  logic [1 :0]               read_ctr_ff;
+  logic                      rd_trans_ff;
+  logic [6 :0]               delay_ctr_ff;
+  logic                      cl_data_en [RD_NUM -1:0];
+  logic [31:0]               cl_data_ff [RD_NUM -1:0];
+
+  genvar rd_idx;
+
+  assign rom_addr_o = ext_req_i ? ext_addr_i : (ram_addr_ff + read_ctr_ff);
+
+  always_ff @(posedge clk)
+    if (rst) begin
+      read_ctr_ff <= '0;
+      rd_trans_ff <= '0;
+      ram_addr_ff <= '0;
+    end else begin
+      rd_trans_ff <= ext_req_i | (rd_trans_ff & ~&read_ctr_ff);
+      read_ctr_ff <= (rd_trans_ff | ext_req_i) ? 2'(read_ctr_ff + 2'b1) : read_ctr_ff;
+      ram_addr_ff <= ext_req_i ? ext_addr_i[AWIDTH-1:0] : ram_addr_ff;
+    end
+
+  generate
+    for (rd_idx = 0 ; rd_idx < RD_NUM;  rd_idx = rd_idx + 1) begin : g_rd
+
+      assign cl_data_en[rd_idx] = (rd_trans_ff | ext_req_i) & (rd_idx == read_ctr_ff);
+
+      always_ff @(posedge clk)
+        if (cl_data_en[rd_idx])
+          cl_data_ff[rd_idx] <= rom_data_i;
+
+      assign ext_data_o[rd_idx*32+:32] = cl_data_ff[rd_idx] ;
+
+    end : g_rd
+  endgenerate
+
+  // Primitive RAM Delay model
+  always_ff @(posedge clk)
+    if (rst)
+      delay_ctr_ff <= '0;
+    else if (ext_req_i | |(delay_ctr_ff))
+      delay_ctr_ff <= ( delay_ctr_ff == MEM_DELAY ) ? '0 : 7'(delay_ctr_ff + 7'b1);
+
+    assign ext_rsp_o = ( delay_ctr_ff == MEM_DELAY );
+ endmodule

--- a/labs/5_cpu/5_3_schoolriscv_cache/sr_register_file.sv
+++ b/labs/5_cpu/5_3_schoolriscv_cache/sr_register_file.sv
@@ -1,0 +1,37 @@
+//
+//  schoolRISCV - small RISC-V CPU
+//
+//  Originally based on Sarah L. Harris MIPS CPU
+//  & schoolMIPS project.
+//
+//  Copyright (c) 2017-2020 Stanislav Zhelnio & Aleksandr Romanov.
+//
+//  Modified in 2024 by Yuri Panchul & Mike Kuskov
+//  for systemverilog-homework project.
+//
+
+`include "sr_cpu.svh"
+
+module sr_register_file
+(
+    input         clk,
+    input  [ 4:0] a0,
+    input  [ 4:0] a1,
+    input  [ 4:0] a2,
+    input  [ 4:0] a3,
+    output [31:0] rd0,
+    output [31:0] rd1,
+    output [31:0] rd2,
+    input  [31:0] wd3,
+    input         we3
+);
+    logic [31:0] rf [0:31];
+
+    assign rd0 = (a0 != 0) ? rf [a0] : 32'b0;
+    assign rd1 = (a1 != 0) ? rf [a1] : 32'b0;
+    assign rd2 = (a2 != 0) ? rf [a2] : 32'b0;
+
+    always_ff @ (posedge clk)
+        if(we3) rf [a3] <= wd3;
+
+endmodule

--- a/labs/5_cpu/5_3_schoolriscv_cache/sr_soc.sv
+++ b/labs/5_cpu/5_3_schoolriscv_cache/sr_soc.sv
@@ -1,0 +1,141 @@
+//
+//  schoolRISCV - small RISC-V CPU
+//
+//  Originally based on Sarah L. Harris MIPS CPU
+//  & schoolMIPS project.
+//
+//  Copyright (c) 2017-2020 Stanislav Zhelnio & Aleksandr Romanov.
+//
+//  Modified in 2024 by Alexander Kirichenko
+//  for systemverilog-homework project.
+//
+
+module sr_soc
+#(
+  parameter bit CACHE_EN = 1'b0 // 1 - enable cache, 0 - disable (block cl_hit signal in the sr_icache module)
+)
+(
+    input           clk,        // clock
+    input           rst,        // reset
+
+    input   [31:0]  soc_data_i, // instruction memory address
+    output  [31:0]  soc_addr_o, // instruction memory data
+
+    input   [ 4:0]  regAddr,    // debug access reg address
+    output  [31:0]  regData,    // debug access reg data
+    
+    output  [31:0]  cycleCnt_o  // clk counter for evaluation program time execution
+);
+
+    //instruction memory
+    wire [31:0]  imAddr;   // instruction memory address
+    wire [31:0]  imData;   // instruction memory data
+    wire         im_req;
+    wire         im_drdy;
+    wire [31:0]  ext_addr;
+    wire         ext_req;
+    wire         ext_rsp;
+    wire [127:0] ext_data;
+
+    //data memory
+    wire [31:0]  mem_addr;
+    wire [31:0]  mem_data;
+    wire         memWrite;
+
+    wire cpu_im_req;
+    assign im_req = init_im_req | cpu_im_req;
+
+    sr_cpu cpu
+    (
+        .clk        ( clk        ),
+        .rst        ( rst        ),
+        .regAddr    ( regAddr    ),
+        .regData    ( regData    ),
+        .im_req     ( cpu_im_req ),
+        .imAddr     ( imAddr     ),
+        .imData     ( imData     ),
+        .im_drdy    ( im_drdy    ),  //cpu pc write enable
+        .memAddr    ( mem_addr   ),
+        .memData    ( mem_data   ),
+        .memWrite   ( memWrite   )
+    );
+
+    sr_icache #(
+        .CACHE_EN(CACHE_EN)
+    )
+    icache
+    (
+        .clk        (clk      ),
+        .rst        (rst      ),
+        .imem_req_i (im_req   ),
+        .imAddr     (imAddr   ),
+        .imData     (imData   ),
+        .im_drdy    (im_drdy  ),
+        .ext_addr_o (ext_addr ),
+        .ext_req_o  (ext_req  ),
+        .ext_rsp_i  (ext_rsp  ),
+        .ext_data_i (ext_data )
+    );
+
+    sr_mem mem_ctrl
+    (
+        .clk        (clk        ),
+        .rst        (rst        ),
+        .ext_addr_i (ext_addr   ),
+        .ext_req_i  (ext_req    ),
+        .ext_rsp_o  (ext_rsp    ),
+        .ext_data_o (ext_data   ),
+        .rom_data_i (soc_data_i ),
+        .rom_addr_o (soc_addr_o )
+    );
+
+    //------------------------------------------------------------------------
+
+    // Reset detect for initial memory request
+    logic d1;
+    logic d2;
+    wire init_im_req;
+
+    always_ff @(posedge clk)
+      if (rst) begin
+        // For a testbench
+        // All registers are zero by default on a FPGA
+        d1 <= 0;
+        d2 <= 0;
+      end else begin
+        d1 <= 1;
+        d2 <= d1;
+      end
+
+    assign init_im_req = d1 & ~d2;
+
+    //------------------------------------------------------------------------
+
+    logic        cnt_en_ff;
+    logic        cnt_clear_ff;
+
+    // performance: cycle counter enable
+    always_ff @(posedge clk)
+        if (rst)
+            cnt_en_ff <= 1'b0;
+        else if (memWrite && (mem_addr == 32'hffff_0020)) // RARS MMIO addresses is 0xffff0000 - 0xffffffe0
+            cnt_en_ff <= mem_data[0];
+
+    // performance: cycle counter clear signal
+    always_ff @(posedge clk)
+        if (rst)
+            cnt_clear_ff <= 1'b0;
+        else if (memWrite && (mem_addr == 32'hffff_0120)) // RARS MMIO addresses is 0xffff0000 - 0xffffffe0
+            cnt_clear_ff <= mem_data[0];
+
+    // performance: cycle counter
+    perf_cycle_counter i_cycle_cnt
+    (
+        .clk        (clk         ),
+        .rst        (rst         ),
+        .en_i       (cnt_en_ff   ),
+        .clear_i    (cnt_clear_ff),
+        .cycleCnt_o (cycleCnt_o  )
+    );
+
+endmodule

--- a/labs/5_cpu/5_3_schoolriscv_cache/tb.sv
+++ b/labs/5_cpu/5_3_schoolriscv_cache/tb.sv
@@ -1,0 +1,153 @@
+//
+//  schoolRISCV - small RISC-V CPU
+//
+//  Originally based on Sarah L. Harris MIPS CPU
+//  & schoolMIPS project.
+//
+//  Copyright (c) 2017-2020 Stanislav Zhelnio & Aleksandr Romanov.
+//
+//  Modified in 2024 by Yuri Panchul & Mike Kuskov
+//  for systemverilog-homework project.
+//
+
+module tb;
+
+    logic        clk;
+    logic        rst;
+
+    wire  [31:0] imAddr;        // instruction memory address
+    wire  [31:0] imData;        // instruction memory data
+
+    logic [ 4:0] regAddr;       // debug access reg address
+    wire  [31:0] regData;       // debug access reg data
+    
+    wire  [31:0] cycleCntPerf;  // clk counter for evaluation program time execution
+
+    sr_soc # (
+        .CACHE_EN (0)           // 1 - enable cache, 0 - disable (block cl_hit signal in the sr_icache module)
+    )
+    soc
+    (
+        .clk        ( clk          ),
+        .rst        ( rst          ),
+
+        .soc_addr_o ( imAddr       ),
+        .soc_data_i ( imData       ),
+
+        .regAddr    ( regAddr      ),
+        .regData    ( regData      ),
+
+        .cycleCnt_o ( cycleCntPerf )
+    );
+
+    instruction_rom # (
+        .SIZE (1024)
+    )
+    rom
+    (
+        .a       ( imAddr  ),
+        .rd      ( imData  )
+    );
+
+    //------------------------------------------------------------------------
+
+    initial
+    begin
+        clk = 1'b0;
+
+        forever
+            # 5 clk = ~ clk;
+    end
+
+    //------------------------------------------------------------------------
+
+    initial
+    begin
+        rst <= 1'bx;
+        repeat (2) @ (posedge clk);
+        rst <= 1'b1;
+        repeat (2) @ (posedge clk);
+        rst <= 1'b0;
+    end
+
+    //------------------------------------------------------------------------
+
+    initial
+    begin
+        `ifdef __ICARUS__
+            // Uncomment the following `define
+            // to generate a VCD file and analyze it using GTKwave
+
+           $dumpvars;
+        `endif
+
+        regAddr <= 5'd10;  // a0 register used for I/O
+
+        @ (negedge rst);
+
+        repeat (2500)
+        begin
+            @ (posedge clk);
+
+            if (  regData == 32'h00213d05    // Fibonacci
+                | regData == 32'h1c8cfc00 )  // Factorial
+            begin
+                $display ("%s PASS", `__FILE__);
+                $display ("Clk count is %d", cycleCntPerf);
+                $finish;
+            end
+        end
+
+        $display ("%s FAIL: none of expected register values occured",
+            `__FILE__);
+
+        $finish;
+    end
+
+    //------------------------------------------------------------------------
+
+    int unsigned cycle = 0;
+    bit was_rst = 1'b0;
+
+    logic [31:0] prev_imAddr;
+    logic [31:0] prev_regData;
+
+    always @ (posedge clk)
+    begin
+        $write ("cycle %5d", cycle ++);
+
+        if (rst)
+        begin
+            $write (" rst");
+            was_rst <= 1'b1;
+        end
+        else
+        begin
+            $write ("    ");
+        end
+
+        if (imAddr !== prev_imAddr)
+            $write (" %h", imAddr);
+        else
+            $write ("         ");
+
+        if (was_rst & ~ rst & $isunknown (imData))
+        begin
+            $display ("%s FAIL: fetched instruction at address %x contains Xs: %x",
+                `__FILE__, imAddr, imData);
+
+            $finish;
+        end
+
+        if (regData !== prev_regData)
+            $write (" %h", regData);
+        else
+            $write ("         ");
+
+        prev_imAddr  <= imAddr;
+        prev_regData <= regData;
+
+        $display;
+    end
+
+endmodule


### PR DESCRIPTION
This is a lab from lesson 23 of digital design school, 2024 year. The lab has been adapted for the latest version of schoolRISCV dated jul 2024.
Icarus verilog simulation supported. FPGA synthesis too.
No SDRAM support, just a slow memory imitator module.

screen_xx.png copies has been removed from all schoolRISCV cache commits.