### PR TITLE
Orange Pi MSOC transferred to Gowin

### DIFF
--- a/boards/README.md
+++ b/boards/README.md
@@ -47,6 +47,7 @@
 * marsohod3gw2
 * Tang Mega 138k
 * Tang Mega 138k Pro
+* Orange Pi MSOC
 * Tang Nano 20k
 * Tang Nano 4k
 * Tang Nano 9k
@@ -59,10 +60,6 @@
 * ice40hx8k_evb_yosys
 * karnix_ecp5_yosys
 * orangecrab_ecp5_yosys
-
-## Orange Pi
-
-* Orange Pi MSOC
 
 ## Efinix (partial support)
 


### PR DESCRIPTION
Список плат для синтеза нужно подкорректировать. Строки Orange Pi, Orange Pi MSOC, Efinix (partial support),  в картинке из Школы убрать из раздела Lattice и Orange Pi MSOC вставить в раздел Gowin.