### PR TITLE
Fix Gowin IO bank voltage conflict

### DIFF
--- a/boards/tang_nano_9k_hdmi_no_tm1638/board_specific.cst
+++ b/boards/tang_nano_9k_hdmi_no_tm1638/board_specific.cst
@@ -2,6 +2,7 @@
 # All I/O pins here are 3.3V compatible unless specified otherwise
 
 IO_LOC "CLK"                52;
+IO_PORT "CLK" IO_TYPE=LVCMOS33;
 
 IO_LOC "KEY[0]"             4;
 IO_LOC "KEY[1]"             3;

--- a/boards/tang_nano_9k_hdmi_tm1638/board_specific.cst
+++ b/boards/tang_nano_9k_hdmi_tm1638/board_specific.cst
@@ -2,6 +2,7 @@
 # All I/O pins here are 3.3V compatible unless specified otherwise
 
 IO_LOC "CLK"                52;
+IO_PORT "CLK" IO_TYPE=LVCMOS33;
 
 IO_LOC "KEY[0]"             4;
 IO_LOC "KEY[1]"             3;

--- a/boards/tang_primer_20k_dock_hdmi_no_tm1638/board_specific.cst
+++ b/boards/tang_primer_20k_dock_hdmi_no_tm1638/board_specific.cst
@@ -2,6 +2,7 @@
 
 // CLK
 IO_LOC  "CLK"         H11;
+IO_PORT "CLK" IO_TYPE=LVCMOS33;
 
 // LED
 IO_LOC  "LED[5]"      L16;

--- a/boards/tang_primer_20k_dock_hdmi_tm1638/board_specific.cst
+++ b/boards/tang_primer_20k_dock_hdmi_tm1638/board_specific.cst
@@ -2,6 +2,7 @@
 
 // CLK
 IO_LOC  "CLK"         H11;
+IO_PORT "CLK" IO_TYPE=LVCMOS33;
 
 // LED
 IO_LOC  "LED[5]"      L16;


### PR DESCRIPTION
On latest Gowin IDE versions (V1.9.11.03 Education) synthesis on Tang nano 4k, 9k and primer 20k with HDMI configuration results in the following error:

```
ERROR  (CT1136) : Bank 0 vccio(1.8) is locked by other constraint or embedded port, conflicting BANK_VCCIO set by 'u_LVDS_clk' : IO_TYPE = LVDS25 in the same bank
ERROR  (CT1136) : Bank 0 vccio(1.8) is locked by other constraint or embedded port, conflicting BANK_VCCIO set by 'u_LVDS_b' : IO_TYPE = LVDS25 in the same bank
ERROR  (CT1136) : Bank 0 vccio(1.8) is locked by other constraint or embedded port, conflicting BANK_VCCIO set by 'u_LVDS_g' : IO_TYPE = LVDS25 in the same bank
ERROR  (CT1136) : Bank 0 vccio(1.8) is locked by other constraint or embedded port, conflicting BANK_VCCIO set by 'gowin_add_iobuf_GPIO_1[7]' : IO_TYPE = LVCMOS33 in the same bank
ERROR  (CT1136) : Bank 0 vccio(1.8) is locked by other constraint or embedded port, conflicting BANK_VCCIO set by 'GPIO_1_3_obuf' : IO_TYPE = LVCMOS33 in the same bank
Physical Constraint parsed completed with errors
```

The cause (at least on primer 20k) is that CLK pin H11 is in the same IO voltage bank as the HDMI LVDS pins - bank 0. For some reason it worked previously, but now it has to be fixed. Only HDMI configurations are affected, LCD and no_hdmi versions still work. 

The solution was found in Sipeed example repositories, which still work with dvi_tx IP on latest versions. To be honest I've no idea why, but setting explicit pin configuration does the trick `IO_TYPE=LVCMOS33`.

I've tested all examples on primer 20k, someone else has to confirm that nano 9k works as well. Tang nano 4k is not fixed, it has other IO bank conflicts and I don't have one at hand to test it.

EDIT: confirmed working on tang nano 9k, ready for merge.