### PR TITLE
Add A7 Lite board support

### DIFF
--- a/boards/a7_lite_35t/board_specific.tcl
+++ b/boards/a7_lite_35t/board_specific.tcl
@@ -1,0 +1,3 @@
+set fpga_board  a7_lite_35t
+set part_name   xc7a35tfgg484-1
+set hw_device   xc7a35t_0

--- a/boards/a7_lite_35t/board_specific.xdc
+++ b/boards/a7_lite_35t/board_specific.xdc
@@ -1,0 +1,63 @@
+# Clock signal
+
+create_clock -add -name sys_clk_pin -period 20.00 -waveform {0 5} [get_ports {CLK_50M}];
+
+set_property PACKAGE_PIN J19 [get_ports CLK_50M]
+set_property IOSTANDARD LVCMOS33 [get_ports CLK_50M]
+
+set_property PACKAGE_PIN L18 [get_ports RESETN]
+set_property IOSTANDARD LVCMOS33 [get_ports RESETN]
+
+# KEYs
+
+set_property PACKAGE_PIN AA1 [get_ports {KEY[0]}]
+set_property PACKAGE_PIN W1 [get_ports {KEY[1]}]
+
+set_property IOSTANDARD LVCMOS33 [get_ports {KEY[0]}]
+set_property IOSTANDARD LVCMOS33 [get_ports {KEY[1]}]
+
+# LEDs
+
+set_property PACKAGE_PIN M18 [get_ports {LED[0]}]
+set_property PACKAGE_PIN N18 [get_ports {LED[1]}]
+
+set_property IOSTANDARD LVCMOS33 [get_ports {LED[0]}]
+set_property IOSTANDARD LVCMOS33 [get_ports {LED[1]}]
+
+# UART
+
+set_property PACKAGE_PIN U2 [get_ports UART_RX]
+set_property PACKAGE_PIN V2 [get_ports UART_TX]
+
+set_property IOSTANDARD LVCMOS33 [get_ports UART_RX]
+set_property IOSTANDARD LVCMOS33 [get_ports UART_TX]
+
+# HDMI
+
+set_property PACKAGE_PIN L19 [get_ports TMDS_CLK_P]
+set_property PACKAGE_PIN K21 [get_ports {TMDS_D_P[0]}]
+set_property PACKAGE_PIN J20 [get_ports {TMDS_D_P[1]}]
+set_property PACKAGE_PIN G17 [get_ports {TMDS_D_P[2]}]
+
+set_property IOSTANDARD TMDS_33 [get_ports TMDS_CLK_P]
+set_property IOSTANDARD TMDS_33 [get_ports {TMDS_D_P[0]}]
+set_property IOSTANDARD TMDS_33 [get_ports {TMDS_D_P[1]}]
+set_property IOSTANDARD TMDS_33 [get_ports {TMDS_D_P[2]}]
+
+# GPIO
+
+set_property PACKAGE_PIN F13 [get_ports {GPIO[0]}]
+set_property PACKAGE_PIN F14 [get_ports {GPIO[1]}]
+set_property PACKAGE_PIN E13 [get_ports {GPIO[2]}]
+set_property PACKAGE_PIN E14 [get_ports {GPIO[3]}]
+set_property PACKAGE_PIN D14 [get_ports {GPIO[4]}]
+set_property PACKAGE_PIN D15 [get_ports {GPIO[5]}]
+set_property PACKAGE_PIN E16 [get_ports {GPIO[6]}]
+set_property PACKAGE_PIN D16 [get_ports {GPIO[7]}]
+set_property PACKAGE_PIN D17 [get_ports {GPIO[8]}]
+set_property PACKAGE_PIN D21 [get_ports {GPIO[9]}]
+set_property PACKAGE_PIN G21 [get_ports {GPIO[10]}]
+set_property PACKAGE_PIN C22 [get_ports {GPIO[11]}]
+set_property PACKAGE_PIN B22 [get_ports {GPIO[12]}]
+
+set_property IOSTANDARD LVCMOS33 [get_ports {GPIO[*]}]

--- a/boards/a7_lite_35t/board_specific_top.sv
+++ b/boards/a7_lite_35t/board_specific_top.sv
@@ -1,0 +1,317 @@
+`include "config.svh"
+`include "lab_specific_board_config.svh"
+`include "swap_bits.svh"
+
+module board_specific_top
+# (
+    parameter clk_mhz       = 50,
+              pixel_mhz     = 25,
+
+              w_key         = 2,
+              w_sw          = 0,
+              w_led         = 2,
+              w_digit       = 0,
+              w_gpio        = 13,
+
+              screen_width  = 640,
+              screen_height = 480,
+
+              w_red         = 8,
+              w_green       = 8,
+              w_blue        = 8,
+
+              w_x           = $clog2 ( screen_width  ),
+              w_y           = $clog2 ( screen_height )
+)
+(
+    input                        CLK_50M,
+    input                        RESETN,
+
+    input  [w_key        - 1:0]  KEY,
+
+    output [w_led        - 1:0]  LED,
+
+    output                       TMDS_CLK_N,
+    output                       TMDS_CLK_P,
+    output [               2:0]  TMDS_D_N,
+    output [               2:0]  TMDS_D_P,
+
+    inout  [w_gpio       - 1:0]  GPIO,
+
+    input                        UART_RX,
+    output                       UART_TX
+);
+
+    //------------------------------------------------------------------------
+
+    clk_wiz i_clk_wiz
+    (
+        .clk_out1   ( serial_clk ),  // 250 mhz
+        .clk_out2   ( clk        ),  // 50 mhz
+        .clk_out3   ( pixel_clk  ),  // 25 mhz
+        .clk_in1    ( CLK_50M    )   // 50 mhz
+    );
+
+    xpm_cdc_async_rst i_xpm_cdc_async_rst
+    (
+       .dest_clk    (   clk       ),
+       .dest_arst   (   rst       ),
+       .src_arst    ( ~ RESETN    )
+    );
+
+    //------------------------------------------------------------------------
+
+    localparam w_tm_key   = 8,
+               w_tm_led   = 8,
+               w_tm_digit = 8;
+
+    //------------------------------------------------------------------------
+
+    `ifdef INSTANTIATE_TM1638_BOARD_CONTROLLER_MODULE
+
+        localparam w_lab_key   = w_tm_key,
+                   w_lab_led   = w_tm_led,
+                   w_lab_digit = w_tm_digit;
+    `else
+        // No need in TM1638 in any form
+        // We create a dummy seven-segment digit
+        // to avoid errors in the labs with seven-segment display
+
+        localparam w_lab_key   = w_key,
+                   w_lab_led   = w_led,
+                   w_lab_digit = 1;  // w_digit;
+    `endif
+
+    //------------------------------------------------------------------------
+
+    wire  [w_tm_key    - 1:0] tm_key;
+    wire  [w_tm_led    - 1:0] tm_led;
+    wire  [w_tm_digit  - 1:0] tm_digit;
+
+    logic [w_lab_key   - 1:0] lab_key;
+    wire  [w_lab_led   - 1:0] lab_led;
+    wire  [w_lab_digit - 1:0] lab_digit;
+
+    wire  [              7:0] abcdefgh;
+
+    wire  [w_x         - 1:0] x;
+    wire  [w_y         - 1:0] y;
+
+    wire  [w_red       - 1:0] lab_red;
+    wire  [w_green     - 1:0] lab_green;
+    wire  [w_blue      - 1:0] lab_blue;
+
+    wire  vtm_red, vtm_green, vtm_blue;
+
+    wire  [w_red       - 1:0] red   = lab_red   ^ { w_red   { vtm_red   } };
+    wire  [w_green     - 1:0] green = lab_green ^ { w_green { vtm_green } };
+    wire  [w_blue      - 1:0] blue  = lab_blue  ^ { w_blue  { vtm_blue  } };
+
+    wire  [             23:0] mic;
+    wire  [             15:0] sound;
+
+    //------------------------------------------------------------------------
+
+    `ifdef INSTANTIATE_TM1638_BOARD_CONTROLLER_MODULE
+
+        assign tm_led   = lab_led;
+        assign tm_digit = lab_digit;
+        assign lab_key  = tm_key;
+
+        assign LED      = w_led' (~ lab_led);
+
+    `else  // no any form of TM1638
+
+        assign lab_key = ~ KEY;
+
+        assign LED = ~ lab_led;
+
+    `endif
+
+    //------------------------------------------------------------------------
+
+    wire slow_clk;
+
+    slow_clk_gen # (.fast_clk_mhz (clk_mhz), .slow_clk_hz (1))
+    i_slow_clk_gen (.slow_clk (slow_clk), .*);
+
+    //------------------------------------------------------------------------
+
+    lab_top
+    # (
+        .clk_mhz       (    clk_mhz           ),
+        .w_key         (    w_lab_key         ),
+        .w_sw          (    w_lab_key         ),
+        .w_led         (    w_lab_led         ),
+        .w_digit       (    w_lab_digit       ),
+        .w_gpio        (    w_gpio            ),
+
+        .screen_width  (   screen_width       ),
+        .screen_height (   screen_height      ),
+
+        .w_red         (   w_red              ),
+        .w_green       (   w_green            ),
+        .w_blue        (   w_blue             )
+    )
+    i_lab_top
+    (
+        .clk           (   clk                ),
+        .slow_clk      (   slow_clk           ),
+        .rst           (   rst                ),
+
+        .key           (   lab_key            ),
+        .sw            (   lab_key            ),
+
+        .led           (   lab_led            ),
+
+        .abcdefgh      (   abcdefgh           ),
+        .digit         (   lab_digit          ),
+
+        .x             (   x                  ),
+        .y             (   y                  ),
+
+        .red           (   lab_red            ),
+        .green         (   lab_green          ),
+        .blue          (   lab_blue           ),
+
+        .uart_rx       (   UART_RX            ),
+        .uart_tx       (   UART_TX            ),
+
+        .mic           (   mic                ),
+        .sound         (   sound              ),
+
+        .gpio          (   GPIO               )
+    );
+
+    //------------------------------------------------------------------------
+
+    wire [$left (abcdefgh):0] hgfedcba;
+    `SWAP_BITS (hgfedcba, abcdefgh);
+
+    //------------------------------------------------------------------------
+
+    `ifdef INSTANTIATE_TM1638_BOARD_CONTROLLER_MODULE
+
+        tm1638_board_controller
+        # (
+            .clk_mhz  ( clk_mhz    ),
+            .w_digit  ( w_tm_digit )
+        )
+        i_tm1638
+        (
+            .clk      ( clk        ),
+            .rst      ( rst        ),
+            .hgfedcba ( hgfedcba   ),
+            .digit    ( tm_digit   ),
+            .ledr     ( tm_led     ),
+            .keys     ( tm_key     ),
+            .sio_data ( GPIO [0]   ),  // GPIO1 pin 1
+            .sio_clk  ( GPIO [1]   ),  // GPIO1 pin 2
+            .sio_stb  ( GPIO [2]   )   // GPIO1 pin 3
+        );
+    `endif
+
+    //------------------------------------------------------------------------
+
+    `ifdef INSTANTIATE_MICROPHONE_INTERFACE_MODULE
+
+        inmp441_mic_i2s_receiver
+        # (
+            .clk_mhz ( clk_mhz  )
+        )
+        i_microphone
+        (
+            .clk     ( clk      ),
+            .rst     ( rst      ),
+            .lr      ( GPIO [4] ),  // GPIO1 pin 5
+            .ws      ( GPIO [5] ),  // GPIO1 pin 6
+            .sck     ( GPIO [6] ),  // GPIO1 pin 7
+            .sd      ( GPIO [7] ),  // GPIO1 pin 8
+            .value   ( mic      )
+        );                          // GPIO1 pin 30 - GND, pin 29 - VCC 3.3V
+
+    `endif
+
+    //------------------------------------------------------------------------
+
+    `ifdef INSTANTIATE_SOUND_OUTPUT_INTERFACE_MODULE
+
+        i2s_audio_out
+        # (
+            .clk_mhz ( clk_mhz     )
+        )
+        inst_audio_out
+        (
+            .clk     ( clk         ),
+            .reset   ( rst         ),
+            .data_in ( sound       ),
+            .mclk    ( GPIO [9]    ), // GPIO1 pin 47
+            .bclk    ( GPIO [10]   ), // GPIO1 pin 48
+            .lrclk   ( GPIO [11]   ), // GPIO1 pin 49
+            .sdata   ( GPIO [12]   )  // GPIO1 pin 50
+        );                            // GPIO1 pin 30 - GND, pin 29 - VCC 3.3V
+
+    `endif
+
+    //------------------------------------------------------------------------
+
+    `ifdef INSTANTIATE_GRAPHICS_INTERFACE_MODULE
+
+        wire [9:0] x10; assign x = x10;
+        wire [9:0] y10; assign y = y10;
+
+        wire red_serial, green_serial, blue_serial;
+
+        dvi_top i_dvi_top (
+            .serial_clk_i   ( serial_clk   ),
+            .pixel_clk_i    ( pixel_clk    ),
+            .rst_i          ( rst          ),
+            .red_i          ( red          ),
+            .green_i        ( green        ),
+            .blue_i         ( blue         ),
+            .x_o            ( x10          ),
+            .y_o            ( y10          ),
+            .red_serial_o   ( red_serial   ),
+            .green_serial_o ( green_serial ),
+            .blue_serial_o  ( blue_serial  )
+        );
+
+        OBUFDS #(
+            .IOSTANDARD ("DEFAULT"),
+            .SLEW       ("SLOW"   )
+        ) OBUFDS_blue (
+            .O  (TMDS_D_P[0]  ),
+            .OB (TMDS_D_N[0]  ),
+            .I  (blue_serial  )
+        );
+
+        OBUFDS #(
+            .IOSTANDARD ("DEFAULT"),
+            .SLEW       ("SLOW"   )
+        ) OBUFDS_green (
+            .O  (TMDS_D_P[1]  ),
+            .OB (TMDS_D_N[1]  ),
+            .I  (green_serial )
+        );
+
+        OBUFDS #(
+            .IOSTANDARD ("DEFAULT"),
+            .SLEW       ("SLOW"   )
+        ) OBUFDS_red (
+            .O  (TMDS_D_P[2]  ),
+            .OB (TMDS_D_N[2]  ),
+            .I  (red_serial   )
+        );
+
+        OBUFDS #(
+            .IOSTANDARD ("DEFAULT"),
+            .SLEW       ("SLOW"   )
+        ) OBUFDS_pixel_clk (
+            .O  (TMDS_CLK_P   ),
+            .OB (TMDS_CLK_N   ),
+            .I  (pixel_clk    )
+        );
+
+    `endif
+
+endmodule

--- a/boards/a7_lite_35t/clk_wiz.v
+++ b/boards/a7_lite_35t/clk_wiz.v
@@ -1,0 +1,92 @@
+
+// file: clk_wiz.v
+// 
+// (c) Copyright 2008 - 2013 Xilinx, Inc. All rights reserved.
+// 
+// This file contains confidential and proprietary information
+// of Xilinx, Inc. and is protected under U.S. and
+// international copyright and other intellectual property
+// laws.
+// 
+// DISCLAIMER
+// This disclaimer is not a license and does not grant any
+// rights to the materials distributed herewith. Except as
+// otherwise provided in a valid license issued to you by
+// Xilinx, and to the maximum extent permitted by applicable
+// law: (1) THESE MATERIALS ARE MADE AVAILABLE "AS IS" AND
+// WITH ALL FAULTS, AND XILINX HEREBY DISCLAIMS ALL WARRANTIES
+// AND CONDITIONS, EXPRESS, IMPLIED, OR STATUTORY, INCLUDING
+// BUT NOT LIMITED TO WARRANTIES OF MERCHANTABILITY, NON-
+// INFRINGEMENT, OR FITNESS FOR ANY PARTICULAR PURPOSE; and
+// (2) Xilinx shall not be liable (whether in contract or tort,
+// including negligence, or under any other theory of
+// liability) for any loss or damage of any kind or nature
+// related to, arising under or in connection with these
+// materials, including for any direct, or any indirect,
+// special, incidental, or consequential loss or damage
+// (including loss of data, profits, goodwill, or any type of
+// loss or damage suffered as a result of any action brought
+// by a third party) even if such damage or loss was
+// reasonably foreseeable or Xilinx had been advised of the
+// possibility of the same.
+// 
+// CRITICAL APPLICATIONS
+// Xilinx products are not designed or intended to be fail-
+// safe, or for use in any application requiring fail-safe
+// performance, such as life-support or safety devices or
+// systems, Class III medical devices, nuclear facilities,
+// applications related to the deployment of airbags, or any
+// other applications that could lead to death, personal
+// injury, or severe property or environmental damage
+// (individually and collectively, "Critical
+// Applications"). Customer assumes the sole risk and
+// liability of any use of Xilinx products in Critical
+// Applications, subject only to applicable laws and
+// regulations governing limitations on product liability.
+// 
+// THIS COPYRIGHT NOTICE AND DISCLAIMER MUST BE RETAINED AS
+// PART OF THIS FILE AT ALL TIMES.
+// 
+//----------------------------------------------------------------------------
+// User entered comments
+//----------------------------------------------------------------------------
+// None
+//
+//----------------------------------------------------------------------------
+//  Output     Output      Phase    Duty Cycle   Pk-to-Pk     Phase
+//   Clock     Freq (MHz)  (degrees)    (%)     Jitter (ps)  Error (ps)
+//----------------------------------------------------------------------------
+// clk_out1__250.00000______0.000______50.0______136.987____164.985
+// clk_out2__50.00000______0.000______50.0______192.113____164.985
+// clk_out3__25.00000______0.000______50.0______236.428____164.985
+//
+//----------------------------------------------------------------------------
+// Input Clock   Freq (MHz)    Input Jitter (UI)
+//----------------------------------------------------------------------------
+// __primary______________50____________0.010
+
+`timescale 1ps/1ps
+
+(* CORE_GENERATION_INFO = "clk_wiz,clk_wiz_v6_0_8_0_0,{component_name=clk_wiz,use_phase_alignment=true,use_min_o_jitter=false,use_max_i_jitter=false,use_dyn_phase_shift=false,use_inclk_switchover=false,use_dyn_reconfig=false,enable_axi=0,feedback_source=FDBK_AUTO,PRIMITIVE=MMCM,num_out_clk=3,clkin1_period=20.000,clkin2_period=10.0,use_power_down=false,use_reset=false,use_locked=false,use_inclk_stopped=false,feedback_type=SINGLE,CLOCK_MGR_TYPE=NA,manual_override=false}" *)
+
+module clk_wiz 
+ (
+  // Clock out ports
+  output        clk_out1,
+  output        clk_out2,
+  output        clk_out3,
+ // Clock in ports
+  input         clk_in1
+ );
+
+  clk_wiz_clk_wiz inst
+  (
+  // Clock out ports  
+  .clk_out1(clk_out1),
+  .clk_out2(clk_out2),
+  .clk_out3(clk_out3),
+ // Clock in ports
+  .clk_in1(clk_in1)
+  );
+
+endmodule

--- a/boards/a7_lite_35t/clk_wiz_clk_wiz.v
+++ b/boards/a7_lite_35t/clk_wiz_clk_wiz.v
@@ -1,0 +1,216 @@
+
+// file: clk_wiz.v
+// 
+// (c) Copyright 2008 - 2013 Xilinx, Inc. All rights reserved.
+// 
+// This file contains confidential and proprietary information
+// of Xilinx, Inc. and is protected under U.S. and
+// international copyright and other intellectual property
+// laws.
+// 
+// DISCLAIMER
+// This disclaimer is not a license and does not grant any
+// rights to the materials distributed herewith. Except as
+// otherwise provided in a valid license issued to you by
+// Xilinx, and to the maximum extent permitted by applicable
+// law: (1) THESE MATERIALS ARE MADE AVAILABLE "AS IS" AND
+// WITH ALL FAULTS, AND XILINX HEREBY DISCLAIMS ALL WARRANTIES
+// AND CONDITIONS, EXPRESS, IMPLIED, OR STATUTORY, INCLUDING
+// BUT NOT LIMITED TO WARRANTIES OF MERCHANTABILITY, NON-
+// INFRINGEMENT, OR FITNESS FOR ANY PARTICULAR PURPOSE; and
+// (2) Xilinx shall not be liable (whether in contract or tort,
+// including negligence, or under any other theory of
+// liability) for any loss or damage of any kind or nature
+// related to, arising under or in connection with these
+// materials, including for any direct, or any indirect,
+// special, incidental, or consequential loss or damage
+// (including loss of data, profits, goodwill, or any type of
+// loss or damage suffered as a result of any action brought
+// by a third party) even if such damage or loss was
+// reasonably foreseeable or Xilinx had been advised of the
+// possibility of the same.
+// 
+// CRITICAL APPLICATIONS
+// Xilinx products are not designed or intended to be fail-
+// safe, or for use in any application requiring fail-safe
+// performance, such as life-support or safety devices or
+// systems, Class III medical devices, nuclear facilities,
+// applications related to the deployment of airbags, or any
+// other applications that could lead to death, personal
+// injury, or severe property or environmental damage
+// (individually and collectively, "Critical
+// Applications"). Customer assumes the sole risk and
+// liability of any use of Xilinx products in Critical
+// Applications, subject only to applicable laws and
+// regulations governing limitations on product liability.
+// 
+// THIS COPYRIGHT NOTICE AND DISCLAIMER MUST BE RETAINED AS
+// PART OF THIS FILE AT ALL TIMES.
+// 
+//----------------------------------------------------------------------------
+// User entered comments
+//----------------------------------------------------------------------------
+// None
+//
+//----------------------------------------------------------------------------
+//  Output     Output      Phase    Duty Cycle   Pk-to-Pk     Phase
+//   Clock     Freq (MHz)  (degrees)    (%)     Jitter (ps)  Error (ps)
+//----------------------------------------------------------------------------
+// clk_out1__250.00000______0.000______50.0______136.987____164.985
+// clk_out2__50.00000______0.000______50.0______192.113____164.985
+// clk_out3__25.00000______0.000______50.0______236.428____164.985
+//
+//----------------------------------------------------------------------------
+// Input Clock   Freq (MHz)    Input Jitter (UI)
+//----------------------------------------------------------------------------
+// __primary______________50____________0.010
+
+`timescale 1ps/1ps
+
+module clk_wiz_clk_wiz 
+
+ (// Clock in ports
+  // Clock out ports
+  output        clk_out1,
+  output        clk_out2,
+  output        clk_out3,
+  input         clk_in1
+ );
+  // Input buffering
+  //------------------------------------
+wire clk_in1_clk_wiz;
+wire clk_in2_clk_wiz;
+  IBUF clkin1_ibufg
+   (.O (clk_in1_clk_wiz),
+    .I (clk_in1));
+
+
+
+
+  // Clocking PRIMITIVE
+  //------------------------------------
+
+  // Instantiation of the MMCM PRIMITIVE
+  //    * Unused inputs are tied off
+  //    * Unused outputs are labeled unused
+
+  wire        clk_out1_clk_wiz;
+  wire        clk_out2_clk_wiz;
+  wire        clk_out3_clk_wiz;
+  wire        clk_out4_clk_wiz;
+  wire        clk_out5_clk_wiz;
+  wire        clk_out6_clk_wiz;
+  wire        clk_out7_clk_wiz;
+
+  wire [15:0] do_unused;
+  wire        drdy_unused;
+  wire        psdone_unused;
+  wire        locked_int;
+  wire        clkfbout_clk_wiz;
+  wire        clkfbout_buf_clk_wiz;
+  wire        clkfboutb_unused;
+    wire clkout0b_unused;
+   wire clkout1b_unused;
+   wire clkout2b_unused;
+   wire clkout3_unused;
+   wire clkout3b_unused;
+   wire clkout4_unused;
+  wire        clkout5_unused;
+  wire        clkout6_unused;
+  wire        clkfbstopped_unused;
+  wire        clkinstopped_unused;
+
+  MMCME2_ADV
+  #(.BANDWIDTH            ("OPTIMIZED"),
+    .CLKOUT4_CASCADE      ("FALSE"),
+    .COMPENSATION         ("ZHOLD"),
+    .STARTUP_WAIT         ("FALSE"),
+    .DIVCLK_DIVIDE        (1),
+    .CLKFBOUT_MULT_F      (20.000),
+    .CLKFBOUT_PHASE       (0.000),
+    .CLKFBOUT_USE_FINE_PS ("FALSE"),
+    .CLKOUT0_DIVIDE_F     (4.000),
+    .CLKOUT0_PHASE        (0.000),
+    .CLKOUT0_DUTY_CYCLE   (0.500),
+    .CLKOUT0_USE_FINE_PS  ("FALSE"),
+    .CLKOUT1_DIVIDE       (20),
+    .CLKOUT1_PHASE        (0.000),
+    .CLKOUT1_DUTY_CYCLE   (0.500),
+    .CLKOUT1_USE_FINE_PS  ("FALSE"),
+    .CLKOUT2_DIVIDE       (40),
+    .CLKOUT2_PHASE        (0.000),
+    .CLKOUT2_DUTY_CYCLE   (0.500),
+    .CLKOUT2_USE_FINE_PS  ("FALSE"),
+    .CLKIN1_PERIOD        (20.000))
+  mmcm_adv_inst
+    // Output clocks
+   (
+    .CLKFBOUT            (clkfbout_clk_wiz),
+    .CLKFBOUTB           (clkfboutb_unused),
+    .CLKOUT0             (clk_out1_clk_wiz),
+    .CLKOUT0B            (clkout0b_unused),
+    .CLKOUT1             (clk_out2_clk_wiz),
+    .CLKOUT1B            (clkout1b_unused),
+    .CLKOUT2             (clk_out3_clk_wiz),
+    .CLKOUT2B            (clkout2b_unused),
+    .CLKOUT3             (clkout3_unused),
+    .CLKOUT3B            (clkout3b_unused),
+    .CLKOUT4             (clkout4_unused),
+    .CLKOUT5             (clkout5_unused),
+    .CLKOUT6             (clkout6_unused),
+     // Input clock control
+    .CLKFBIN             (clkfbout_buf_clk_wiz),
+    .CLKIN1              (clk_in1_clk_wiz),
+    .CLKIN2              (1'b0),
+     // Tied to always select the primary input clock
+    .CLKINSEL            (1'b1),
+    // Ports for dynamic reconfiguration
+    .DADDR               (7'h0),
+    .DCLK                (1'b0),
+    .DEN                 (1'b0),
+    .DI                  (16'h0),
+    .DO                  (do_unused),
+    .DRDY                (drdy_unused),
+    .DWE                 (1'b0),
+    // Ports for dynamic phase shift
+    .PSCLK               (1'b0),
+    .PSEN                (1'b0),
+    .PSINCDEC            (1'b0),
+    .PSDONE              (psdone_unused),
+    // Other control and status signals
+    .LOCKED              (locked_int),
+    .CLKINSTOPPED        (clkinstopped_unused),
+    .CLKFBSTOPPED        (clkfbstopped_unused),
+    .PWRDWN              (1'b0),
+    .RST                 (1'b0));
+
+// Clock Monitor clock assigning
+//--------------------------------------
+ // Output buffering
+  //-----------------------------------
+
+  BUFG clkf_buf
+   (.O (clkfbout_buf_clk_wiz),
+    .I (clkfbout_clk_wiz));
+
+
+
+
+
+
+  BUFG clkout1_buf
+   (.O   (clk_out1),
+    .I   (clk_out1_clk_wiz));
+
+
+  BUFG clkout2_buf
+   (.O   (clk_out2),
+    .I   (clk_out2_clk_wiz));
+
+  BUFG clkout3_buf
+   (.O   (clk_out3),
+    .I   (clk_out3_clk_wiz));
+
+
+
+endmodule

--- a/peripherals/dvi_pkg.svh
+++ b/peripherals/dvi_pkg.svh
@@ -1,0 +1,39 @@
+`ifndef DVI_PKG_SVH
+`define DVI_PKG_SVH
+
+package dvi_pkg;
+
+    parameter SCREEN_H_RES  = 640;
+    parameter SCREEN_V_RES  = 480;
+
+    parameter HSYNC_PULSE   = 96;
+    parameter H_FRONT_PORCH = 16;
+    parameter H_BACK_PORCH  = 48;
+    parameter H_BORDER      = 0;
+
+    parameter VSYNC_PULSE   = 2;
+    parameter V_FRONT_PORCH = 10;
+    parameter V_BACK_PORCH  = 33;
+    parameter V_BORDER      = 0;
+
+    // HSYNC
+    parameter HSYNC_START   = SCREEN_H_RES + H_BORDER + H_FRONT_PORCH;
+    parameter HSYNC_END     = HSYNC_START + HSYNC_PULSE;
+    parameter H_TOTAL       = HSYNC_END + H_BACK_PORCH + H_BORDER;
+
+    // VSYNC
+    parameter VSYNC_START   = SCREEN_V_RES + V_BORDER + V_FRONT_PORCH;
+    parameter VSYNC_END     = VSYNC_START + VSYNC_PULSE;
+    parameter V_TOTAL       = VSYNC_END + V_BACK_PORCH + V_BORDER;
+
+    parameter X_POS_W       = $clog2(SCREEN_H_RES + 1);
+    parameter Y_POS_W       = $clog2(SCREEN_V_RES + 1);
+
+    parameter HS_W       = $clog2(H_TOTAL + 1);
+    parameter VS_W       = $clog2(V_TOTAL + 1);
+
+    parameter COLOR_W       = 8;
+
+endpackage : dvi_pkg
+
+`endif

--- a/peripherals/dvi_sync.sv
+++ b/peripherals/dvi_sync.sv
@@ -1,0 +1,64 @@
+`include "dvi_pkg.svh"
+
+// `default_nettype none
+
+module dvi_sync
+    import dvi_pkg::*;
+(
+    input  logic               clk_i,
+    input  logic               rst_i,
+    output logic               hsync_o,
+    output logic               vsync_o,
+    output logic [X_POS_W-1:0] pixel_x_o,
+    output logic [Y_POS_W-1:0] pixel_y_o,
+    output logic               visible_range_o
+);
+
+    logic            h_cnt_max;
+    logic [HS_W-1:0] h_cnt_next;
+    logic [HS_W-1:0] h_cnt;
+    logic [VS_W-1:0] v_cnt_next;
+    logic [VS_W-1:0] v_cnt;
+
+    always_comb begin
+        h_cnt_max  = h_cnt == (H_TOTAL - 1);
+        h_cnt_next = h_cnt_max ? '0 : h_cnt + 1'b1;
+        v_cnt_next = v_cnt;
+
+        if (h_cnt_max) begin
+            v_cnt_next = v_cnt + 1'b1;
+
+            if (v_cnt == (V_TOTAL - 1))
+                v_cnt_next = '0;
+        end
+    end
+
+    always_ff @(posedge clk_i) begin
+        if (rst_i) begin
+            h_cnt <= '0;
+            v_cnt <= '0;
+        end else begin
+            h_cnt <= h_cnt_next;
+            v_cnt <= v_cnt_next;
+        end
+    end
+
+    // Register outputs
+    always_ff @(posedge clk_i)
+        if (rst_i) begin
+            hsync_o         <= '0;
+            vsync_o         <= '0;
+            pixel_x_o       <= '0;
+            pixel_y_o       <= '0;
+            visible_range_o <= '0;
+        end else begin
+            hsync_o         <= !(h_cnt_next >= HSYNC_START && h_cnt_next < HSYNC_END);
+            vsync_o         <= !(v_cnt_next >= VSYNC_START && v_cnt_next < VSYNC_END);
+
+            pixel_x_o       <=  (h_cnt_next > SCREEN_H_RES - 1) ? '0 : X_POS_W'(h_cnt_next);
+            pixel_y_o       <=  (v_cnt_next > SCREEN_V_RES - 1) ? '0 : Y_POS_W'(v_cnt_next);
+
+            visible_range_o <=  ((h_cnt_next < SCREEN_H_RES) && (v_cnt_next < SCREEN_V_RES));
+        end
+
+endmodule

--- a/peripherals/dvi_top.sv
+++ b/peripherals/dvi_top.sv
@@ -1,0 +1,130 @@
+`include "dvi_pkg.svh"
+
+// `default_nettype none
+
+module dvi_top
+    import dvi_pkg::X_POS_W;
+    import dvi_pkg::Y_POS_W;
+    import dvi_pkg::COLOR_W;
+(
+    input  logic               serial_clk_i,
+    input  logic               pixel_clk_i,
+    input  logic               rst_i,
+
+    input  logic [COLOR_W-1:0] red_i,
+    input  logic [COLOR_W-1:0] green_i,
+    input  logic [COLOR_W-1:0] blue_i,
+
+    output logic [X_POS_W-1:0] x_o,
+    output logic [Y_POS_W-1:0] y_o,
+
+    output logic               red_serial_o,
+    output logic               green_serial_o,
+    output logic               blue_serial_o
+);
+
+    logic               hsync;
+    logic               vsync;
+    logic               visible_range;
+    logic               hsync_r;
+    logic               vsync_r;
+    logic               visible_range_r;
+
+    logic [        9:0] red_tmds;
+    logic [        9:0] green_tmds;
+    logic [        9:0] blue_tmds;
+
+    // ------------------------------------------------------------------------
+    // Sync
+    // ------------------------------------------------------------------------
+
+    dvi_sync i_dvi_sync (
+        .clk_i           ( pixel_clk_i   ),
+        .rst_i           ( rst_i         ),
+        .hsync_o         ( hsync         ),
+        .vsync_o         ( vsync         ),
+        .pixel_x_o       ( x_o           ),
+        .pixel_y_o       ( y_o           ),
+        .visible_range_o ( visible_range )
+    );
+
+    // ------------------------------------------------------------------------
+    // Encode
+    // ------------------------------------------------------------------------
+
+    // Delay hsync/vsync and visible_range by 1 clock cycle to account for color
+    // delay in image_gen
+    always_ff @(posedge pixel_clk_i) begin
+        if (rst_i) begin
+            hsync_r         <= '0;
+            vsync_r         <= '0;
+            visible_range_r <= '0;
+        end else begin
+            hsync_r         <= hsync;
+            vsync_r         <= vsync;
+            visible_range_r <= visible_range;
+        end
+    end
+
+    tmds_encoder blue_encoder (
+        .clk_i ( pixel_clk_i     ),
+        .rst_i ( rst_i           ),
+        .C0    ( hsync_r         ),
+        .C1    ( vsync_r         ),
+        .DE    ( visible_range_r ),
+        .D     ( blue_i          ),
+        .q_out ( blue_tmds       )
+    );
+
+    tmds_encoder green_encoder (
+        .clk_i ( pixel_clk_i     ),
+        .rst_i ( rst_i           ),
+        .C0    ( 1'b0            ),
+        .C1    ( 1'b0            ),
+        .DE    ( visible_range_r ),
+        .D     ( green_i         ),
+        .q_out ( green_tmds      )
+    );
+
+    tmds_encoder red_encoder (
+        .clk_i ( pixel_clk_i     ),
+        .rst_i ( rst_i           ),
+        .C0    ( 1'b0            ),
+        .C1    ( 1'b0            ),
+        .DE    ( visible_range_r ),
+        .D     ( red_i           ),
+        .q_out ( red_tmds        )
+    );
+
+    // ------------------------------------------------------------------------
+    // Serialize
+    // ------------------------------------------------------------------------
+
+    serializer #(
+        .DATA_W ( 10 )
+    ) blue_serializer (
+        .clk_i  ( serial_clk_i ),
+        .rst_i  ( rst_i        ),
+        .data_i ( blue_tmds    ),
+        .data_o ( blue_serial_o  )
+    );
+
+    serializer #(
+        .DATA_W ( 10 )
+    ) green_serializer (
+        .clk_i  ( serial_clk_i ),
+        .rst_i  ( rst_i        ),
+        .data_i ( green_tmds   ),
+        .data_o ( green_serial_o )
+    );
+
+    serializer #(
+        .DATA_W ( 10 )
+    ) red_serializer (
+        .clk_i  ( serial_clk_i ),
+        .rst_i  ( rst_i        ),
+        .data_i ( red_tmds     ),
+        .data_o ( red_serial_o   )
+    );
+
+endmodule

--- a/peripherals/serializer.sv
+++ b/peripherals/serializer.sv
@@ -1,0 +1,42 @@
+// `default_nettype none
+
+module serializer #(
+    parameter DATA_W = 10
+) (
+    input  logic              clk_i,
+    input  logic              rst_i,
+    input  logic [DATA_W-1:0] data_i,
+    output logic              data_o
+);
+
+    localparam CNT_MAX = DATA_W - 1;
+
+    logic [DATA_W-1:0] shift_reg;
+    logic [       3:0] cnt;
+    logic              load;
+
+    assign load = cnt == CNT_MAX;
+
+    always_ff @(posedge clk_i) begin
+        if (rst_i) begin
+            cnt <= '0;
+        end else if (load) begin
+            cnt <= '0;
+        end else begin
+            cnt <= cnt + 1'b1;
+        end
+    end
+
+    always_ff @(posedge clk_i) begin
+        if (rst_i) begin
+            shift_reg <= '0;
+        end else if (load) begin
+            shift_reg <= data_i;
+        end else begin
+            shift_reg <= { 1'b0, shift_reg[DATA_W-1:1] };
+        end
+    end
+
+    assign data_o = shift_reg[0];
+
+endmodule

--- a/peripherals/tmds_encoder.sv
+++ b/peripherals/tmds_encoder.sv
@@ -1,0 +1,108 @@
+// `default_nettype none
+
+module tmds_encoder (
+    input  logic       clk_i,
+    input  logic       rst_i,
+    input  logic       C0,
+    input  logic       C1,
+    input  logic       DE,
+    input  logic [7:0] D,
+    output logic [9:0] q_out
+);
+
+    localparam W_CNT = 8;
+
+    logic signed [W_CNT-1:0] cnt;
+    logic signed [W_CNT-1:0] cnt_next;
+    logic              [8:0] q_m;
+    logic              [9:0] q_next;
+    logic              [3:0] N1D;
+    logic              [3:0] N1_qm;
+    logic              [3:0] N0_qm;
+
+
+    always_comb begin
+        N1D = 4'(D[0]) + 4'(D[1]) + 4'(D[2]) + 4'(D[3])
+            + 4'(D[4]) + 4'(D[5]) + 4'(D[6]) + 4'(D[7]);
+
+        q_m[0] = D[0];
+
+        if ((N1D > 4) || (N1D == 4 && ~D[0])) begin
+            // verilator lint_off ALWCOMBORDER
+            q_m[8] = 1'b0;
+
+            for (int i = 0; i < 7; i++) begin
+                q_m[i + 1] = q_m[i] ~^ D[i + 1];
+            end
+            // verilator lint_on ALWCOMBORDER
+
+        end else begin
+            q_m[8] = 1'b1;
+
+            for (int i = 0; i < 7; i++) begin
+                q_m[i + 1] = q_m[i] ^ D[i + 1];
+            end
+        end
+
+        N1_qm = 4'(q_m[0]) + 4'(q_m[1]) + 4'(q_m[2]) + 4'(q_m[3])
+              + 4'(q_m[4]) + 4'(q_m[5]) + 4'(q_m[6]) + 4'(q_m[7]);
+
+        N0_qm = 4'(!q_m[0]) + 4'(!q_m[1]) + 4'(!q_m[2]) + 4'(!q_m[3])
+              + 4'(!q_m[4]) + 4'(!q_m[5]) + 4'(!q_m[6]) + 4'(!q_m[7]);
+
+        if (DE) begin
+            if ((cnt == 0) || (N1_qm == N0_qm)) begin
+                q_next[9]   = ~q_m[8];
+                q_next[8]   =  q_m[8];
+                q_next[7:0] =  q_m[8] ? q_m[7:0] : ~q_m[7:0];
+
+                if (~q_m[8]) begin
+                    cnt_next = cnt + W_CNT'(N0_qm) -  W_CNT'(N1_qm);
+                end else begin
+                    cnt_next = cnt + W_CNT'(N1_qm) - W_CNT'(N0_qm);
+                end
+
+            end else begin
+                if (((cnt > 0) && (N1_qm > N0_qm)) ||
+                    ((cnt < 0) && (N0_qm > N1_qm))) begin
+
+                    q_next[9]   = 1'b1;
+                    q_next[8]   = q_m[8];
+                    q_next[7:0] = ~q_m[7:0];
+                    cnt_next    = cnt + (W_CNT'(q_m[8]) << 1) +
+                                        W_CNT'(N0_qm) - W_CNT'(N1_qm);
+
+                end else begin
+                    q_next[9]   = 1'b0;
+                    q_next[8]   = q_m[8];
+                    q_next[7:0] = q_m[7:0];
+                    cnt_next    = cnt - (W_CNT'({~q_m[8]}) << 1) +
+                                        W_CNT'(N1_qm) - W_CNT'(N0_qm);
+                end
+            end
+
+        end else begin
+            cnt_next = '0;
+
+            case ({C1, C0})
+                2'b00: q_next = 10'b1101010100;
+                2'b01: q_next = 10'b0010101011;
+                2'b10: q_next = 10'b0101010100;
+                2'b11: q_next = 10'b1010101011;
+            endcase
+        end
+    end
+
+    always_ff @(posedge clk_i) begin
+        if (rst_i) begin
+            cnt <= '0;
+        end else begin
+            cnt <= cnt_next;
+        end
+    end
+
+    always_ff @(posedge clk_i) begin
+        q_out <= q_next;
+    end
+
+endmodule

--- a/scripts/fpga/xilinx_vivado_synthesize.tcl
+++ b/scripts/fpga/xilinx_vivado_synthesize.tcl
@@ -27,7 +27,7 @@ foreach file [glob ../*.{v,sv}] {
 
 read_verilog -sv [glob $extra_dot_dot../../../../peripherals/*.sv]
 
-read_verilog -sv [glob $extra_dot_dot../../../../boards/$fpga_board/*.sv]
+read_verilog -sv [glob $extra_dot_dot../../../../boards/$fpga_board/*.{v,sv}]
 
 read_xdc $extra_dot_dot../../../../boards/$fpga_board/board_specific.xdc
 

--- a/scripts/steps/00_setup.source_bash
+++ b/scripts/steps/00_setup.source_bash
@@ -335,6 +335,7 @@ update_fpga_toolchain_var ()
             fpga_toolchain=efinity
         ;;
 
+        a7_lite*                         | \
         alinx_ax7035b*                   | \
         arty_a7*                         | \
         arty_s7                          | \


### PR DESCRIPTION
Add Chinese MicroPhase [A7 Lite 35T](https://www.aliexpress.us/item/3256809647416013.html) board support.
To work with onboard HDMI [Open DVI driver](https://github.com/max-kudinov/open_dvi) is used.
Separately generated Vivado IP core is used for graphics clocking. 