### PR TITLE
Migrate OpenLane Flow to Librelane

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 run/
 work/
+librelane_designs/
 log.txt
 fpga_board_selection

--- a/flake.lock
+++ b/flake.lock
@@ -74,7 +74,7 @@
       },
       "original": {
         "owner": "librelane",
-        "ref": "dev",
+        "ref": "3.0.0",
         "repo": "librelane",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,125 @@
+{
+  "nodes": {
+    "ciel": {
+      "inputs": {
+        "nix-eda": [
+          "librelane",
+          "nix-eda"
+        ]
+      },
+      "locked": {
+        "lastModified": 1764091696,
+        "narHash": "sha256-AWbkHL0zO3tD0mE3dZIcj8mVND7o3imTxOpEfOtlRDI=",
+        "owner": "fossi-foundation",
+        "repo": "ciel",
+        "rev": "afcb23d368614ffa1e7e96584ed33f839c71c576",
+        "type": "github"
+      },
+      "original": {
+        "owner": "fossi-foundation",
+        "repo": "ciel",
+        "type": "github"
+      }
+    },
+    "devshell": {
+      "inputs": {
+        "nixpkgs": [
+          "librelane",
+          "nix-eda",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1768818222,
+        "narHash": "sha256-460jc0+CZfyaO8+w8JNtlClB2n4ui1RbHfPTLkpwhU8=",
+        "owner": "numtide",
+        "repo": "devshell",
+        "rev": "255a2b1725a20d060f566e4755dbf571bbbb5f76",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "devshell",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "locked": {
+        "lastModified": 1733328505,
+        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
+        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
+        "revCount": 69,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/edolstra/flake-compat/1.1.0/01948eb7-9cba-704f-bbf3-3fa956735b52/source.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz"
+      }
+    },
+    "librelane": {
+      "inputs": {
+        "ciel": "ciel",
+        "devshell": "devshell",
+        "flake-compat": "flake-compat",
+        "nix-eda": "nix-eda"
+      },
+      "locked": {
+        "lastModified": 1774453904,
+        "narHash": "sha256-BZmoneeMpnnQ2wUb5sorLFsFZsLaKclhAtCIiMsW8Qc=",
+        "owner": "librelane",
+        "repo": "librelane",
+        "rev": "69b2067bd2b5eb89b84649b76e9edaa9e51e6735",
+        "type": "github"
+      },
+      "original": {
+        "owner": "librelane",
+        "ref": "dev",
+        "repo": "librelane",
+        "type": "github"
+      }
+    },
+    "nix-eda": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1773918136,
+        "narHash": "sha256-nSKBMGP8/ZC7qB3Lzd+FwM8REqOxlh8wpYDf2hlK6Gg=",
+        "owner": "fossi-foundation",
+        "repo": "nix-eda",
+        "rev": "8f990fb77529c09e540e453cd836af9930ec58db",
+        "type": "github"
+      },
+      "original": {
+        "owner": "fossi-foundation",
+        "ref": "6.11.0",
+        "repo": "nix-eda",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1766201043,
+        "narHash": "sha256-eplAP+rorKKd0gNjV3rA6+0WMzb1X1i16F5m5pASnjA=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "b3aad468604d3e488d627c0b43984eb60e75e782",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "librelane": "librelane"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -9,7 +9,7 @@
   };
 
   inputs = {
-    librelane.url = "github:librelane/librelane/dev";
+    librelane.url = "github:librelane/librelane/3.0.0";
   };
 
   outputs =
@@ -34,12 +34,6 @@
             nix-eda.overlays.default
             devshell.overlays.default
             librelane.overlays.default
-            (final: prev: {
-              klayout = prev.klayout.override {
-                version = "0.30.4";
-                sha256 = "sha256-eL1RjqZpZI3+20ax+NsQ3qoOPzdm4k6KJwW+Rn0wg8Y=";
-              };
-            })
           ];
         }
       );

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,89 @@
+{
+  nixConfig = {
+    extra-substituters = [
+      "https://nix-cache.fossi-foundation.org"
+    ];
+    extra-trusted-public-keys = [
+      "nix-cache.fossi-foundation.org:3+K59iFwXqKsL7BNu6Guy0v+uTlwsxYQxjspXzqLYQs="
+    ];
+  };
+
+  inputs = {
+    librelane.url = "github:librelane/librelane/dev";
+  };
+
+  outputs =
+    {
+      self,
+      librelane,
+      ...
+    }:
+    let
+      nix-eda = librelane.inputs.nix-eda;
+      devshell = librelane.inputs.devshell;
+      nixpkgs = nix-eda.inputs.nixpkgs;
+      lib = nixpkgs.lib;
+    in
+    {
+      # Outputs
+      legacyPackages = nix-eda.forAllSystems (
+        system:
+        import nixpkgs {
+          inherit system;
+          overlays = [
+            nix-eda.overlays.default
+            devshell.overlays.default
+            librelane.overlays.default
+            (final: prev: {
+              klayout = prev.klayout.override {
+                version = "0.30.4";
+                sha256 = "sha256-eL1RjqZpZI3+20ax+NsQ3qoOPzdm4k6KJwW+Rn0wg8Y=";
+              };
+            })
+          ];
+        }
+      );
+
+      packages = nix-eda.forAllSystems (system: {
+        inherit (self.legacyPackages.${system}.python3.pkgs) ;
+      });
+
+      devShells = nix-eda.forAllSystems (
+        system:
+        let
+          pkgs = (self.legacyPackages.${system});
+          callPackage = lib.callPackageWith pkgs;
+        in
+        {
+          default = pkgs.librelane-shell.override ({
+            extra-packages = with pkgs; [
+              # Utilities
+              gnumake
+              gnugrep
+              gawk
+
+              # Simulation
+              iverilog
+              verilator
+
+              # Waveform viewing
+              gtkwave
+              surfer
+
+              # For RARS
+              javaPackages.compiler.temurin-bin.jre-25
+            ];
+
+            extra-python-packages =
+              ps: with ps; [
+                # Verification
+                cocotb
+
+                # For KLayout Python DRC runner
+                docopt
+              ];
+          });
+        }
+      );
+    };
+}

--- a/scripts/asic/asic_top.sv
+++ b/scripts/asic/asic_top.sv
@@ -46,8 +46,8 @@ module asic_top
         .abcdefgh  ( abcdefgh ),
         .digit     ( digit    ),
 
-        .vsync     (          ),
-        .hsync     (          ),
+//        .vsync     (          ),
+//        .hsync     (          ),
         .red       (          ),
         .green     (          ),
         .blue      (          ),

--- a/scripts/asic/config.tcl
+++ b/scripts/asic/config.tcl
@@ -6,9 +6,11 @@ set ::env(VERILOG_FILES) [glob $::env(DESIGN_DIR)/src/*.{v,sv}]
 set ::env(CLOCK_PORT) "clk"
 
 set ::env(FP_SIZING) "absolute"
-set ::env(DIE_AREA) {0 0 100 100}
+set ::env(DIE_AREA) {0 0 1000 1000}
 
 set filename $::env(DESIGN_DIR)/$::env(PDK)_$::env(STD_CELL_LIBRARY)_config.tcl
+
+set ::env(ERROR_ON_LINTER_WARNINGS) 0
 
 if { [file exists $filename] == 1} {
   source $filename

--- a/scripts/asic/sky130A_sky130_fd_sc_hd_config.tcl
+++ b/scripts/asic/sky130A_sky130_fd_sc_hd_config.tcl
@@ -1,5 +1,7 @@
 # SCL Configs
 
+set ::env(PDK) "sky130A"
+
 set ::env(CLOCK_PERIOD) "14"
 set ::env(FP_CORE_UTIL) 40
 set ::env(SYNTH_MAX_FANOUT) 6

--- a/scripts/steps/00_setup.source_bash
+++ b/scripts/steps/00_setup.source_bash
@@ -200,7 +200,7 @@ source "$script_dir/steps/00_setup_intel_fpga.source_bash"
 source "$script_dir/steps/00_setup_gowin.source_bash"
 source "$script_dir/steps/00_setup_efinity.source_bash"
 source "$script_dir/steps/00_setup_xilinx.source_bash"
-source "$script_dir/steps/00_setup_open_lane.source_bash"
+source "$script_dir/steps/00_setup_libre_lane.source_bash"
 source "$script_dir/steps/00_setup_icarus.source_bash"
 source "$script_dir/steps/00_setup_yosys.source_bash"
 source "$script_dir/steps/00_setup_rars.source_bash"
@@ -488,7 +488,7 @@ case $fpga_toolchain in
     yosys   ) setup_yosys         ;;
 esac
 
-openlane_setup
+librelane_setup
 icarus_verilog_setup
 
 if [ -f ../program.s ] ; then

--- a/scripts/steps/00_setup_libre_lane.source_bash
+++ b/scripts/steps/00_setup_libre_lane.source_bash
@@ -1,0 +1,55 @@
+expected_source_script=00_setup.source_bash
+
+if [ -z "$BASH_SOURCE" ]
+then
+    printf "script \"%s\" should be sourced from \"%s\"\n"  \
+        "$0" "$expected_source_script" 1>&2
+
+    exit 1
+fi
+
+this_script=$(basename "${BASH_SOURCE[0]}")
+source_script=$(basename "${BASH_SOURCE[1]}")
+
+if [ -z "$source_script" ]
+then
+    printf "script \"%s\" should be sourced from  \"%s\"\n"  \
+        "$this_script" "$expected_source_script" 1>&2
+
+    return 1
+fi
+
+if [ "$source_script" != $expected_source_script ]
+then
+    printf "script \"%s\" should be sourced from  \"%s\", not \"%s\"\n"  \
+        "$this_script" "$expected_source_script" "$source_script" 1>&2
+
+    exit 1
+fi
+
+#-----------------------------------------------------------------------------
+
+librelane_setup()
+{
+    if ! [[ $script =~ asic ]] ; then
+        return
+    fi
+
+    if [ -v "LIBRELANE_PATH" ]; then
+	export PATH="${LIBRELANE_PATH}:$PATH"
+
+    if  ! is_command_available librelane ; then
+        error "Cannot find librelane binary for ASIC synthesis." \
+              "Librelane can be installed via Nix and sourcing into" \
+              "a Nix development shell with nix develop, or by" \
+              "specifying a custom Librelane binary path with" \
+              "LIBRELANE_PATH"
+    fi
+}
+
+#-----------------------------------------------------------------------------
+
+run_openlane_layout_viewer ()
+{
+    error "TODO: to be implemented"
+}

--- a/scripts/steps/00_setup_libre_lane.source_bash
+++ b/scripts/steps/00_setup_libre_lane.source_bash
@@ -37,11 +37,12 @@ librelane_setup()
 
     if [ -v "LIBRELANE_PATH" ]; then
 	export PATH="${LIBRELANE_PATH}:$PATH"
+    fi
 
     if  ! is_command_available librelane ; then
         error "Cannot find librelane binary for ASIC synthesis." \
               "Librelane can be installed via Nix and sourcing into" \
-              "a Nix development shell with nix develop, or by" \
+              "a Nix development shell with \'nix develop\', or by" \
               "specifying a custom Librelane binary path with" \
               "LIBRELANE_PATH"
     fi

--- a/scripts/steps/00_setup_libre_lane.source_bash
+++ b/scripts/steps/00_setup_libre_lane.source_bash
@@ -50,7 +50,23 @@ librelane_setup()
 
 #-----------------------------------------------------------------------------
 
-run_openlane_layout_viewer ()
+run_librelane_layout_viewer ()
 {
-    error "TODO: to be implemented"
+    # copied form 07_synthesize_for_asic.source_bash
+    top_level_dir=$(git rev-parse --show-toplevel)
+    design_dir="$top_level_dir/librelane_designs/$lab_name"
+
+    if [ -z "${1-}" ]; then
+        LAYOUT_VIEWER="${LAYOUT_VIEWER:-openroad}"
+    fi
+
+    pushd $design_dir &> /dev/null
+    if [ "${1-}" == "klayout" ] || [ LAYOUT_VIEWER == "klayout" ];  then
+        librelane --last-run --flow openinklayout ./config.tcl
+    elif [ "${1-}" == "openroad" ] || [ LAYOUT_VIEWER == "openroad" ] ; then
+        librelane --last-run --flow openinopenroad ./config.tcl
+    else
+        error 'Invalid layout viewer. Valid layout viewers are "klayout" and "openroad"'
+    fi
+    popd
 }

--- a/scripts/steps/07_synthesize_for_asic.source_bash
+++ b/scripts/steps/07_synthesize_for_asic.source_bash
@@ -59,4 +59,4 @@ pushd $design_dir &> /dev/null
 librelane --flow Classic $design_dir/config.tcl
 popd
 
-echo "Done running Librelane flow. The run and its reports can be viewed at ${design_dir}/src"
+echo "Done running Librelane flow. The run and its reports can be viewed at ${design_dir}"

--- a/scripts/steps/07_synthesize_for_asic.source_bash
+++ b/scripts/steps/07_synthesize_for_asic.source_bash
@@ -1,8 +1,10 @@
 . "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/00_setup.source_bash"
 
-design_dir="$openlane_dir/designs/$lab_name"
+# maybe this is fine; maybe this can be changed
+top_level_dir=$(git rev-parse --show-toplevel)
+design_dir="$top_level_dir/librelane_designs/$lab_name"
 
-mkdir -p  "$design_dir/src"
+mkdir -p $design_dir/src
 
 rm    -rf "$design_dir"/*.tcl      \
           "$design_dir/src"/*.{v,vh,sv,svh}  \
@@ -53,31 +55,8 @@ fi
 
 #-----------------------------------------------------------------------------
 
-pushd "$openlane_dir" &> /dev/null
-make quick_run QUICK_RUN_DESIGN=$lab_name 2>&1 | tee "$log"
+pushd $design_dir &> /dev/null
+librelane --flow Classic $design_dir/config.tcl
 popd
 
-#-----------------------------------------------------------------------------
-
-runs_dir="$design_dir/runs"
-
-[ -d "$runs_dir" ] || error "Cannot find OpenLane runs directory"
-
-last_run_dir=$(ls -d "$runs_dir"/RUN* | sort | tail -1)
-
-! [ -z "$last_run_dir" ] || error "No RUN directory"
-
-cp "$log" asic_01_main.log
-
-   cp "$last_run_dir"/results/synthesis/asic_top.v            asic_02_synthesis.v                           \
-&& cp "$last_run_dir"/results/placement/asic_top.nl.v         asic_03_placement.nl.v                        \
-&& cp "$last_run_dir"/results/routing/asic_top.nl.v           asic_04_routing.nl.v                          \
-&& cp "$last_run_dir"/results/final/verilog/gl/asic_top.nl.v  asic_05_final_no_power_grid.nl.v              \
-&& cp "$last_run_dir"/results/final/verilog/gl/asic_top.v     asic_06_final.v                               \
-&& cp "$last_run_dir"/reports/signoff/31-rcx_sta.max.rpt      asic_07_static_timing_analysis.sta.max.rpt    \
-&& cp "$last_run_dir"/reports/signoff/31-rcx_sta.min.rpt      asic_08_static_timing_analysis.sta.min.rpt    \
-&& cp "$last_run_dir"/reports/signoff/31-rcx_sta.power.rpt    asic_09_static_timing_analysis.sta.power.rpt  \
-&& cp "$last_run_dir"/results/signoff/asic_top.lef            asic_10_library_exchange_format.lef           \
-&& cp "$last_run_dir"/results/signoff/asic_top.mag            asic_11_magic.mag                             \
-&& cp "$last_run_dir"/results/signoff/asic_top.sdf            asic_12_standard_delay_format.sdf             \
-|| error "Cannot copy something"
+echo "Done running Librelane flow. The run and its reports can be viewed at ${design_dir}/src"

--- a/scripts/steps/08_visualize_asic_synthesis_results_1.source_bash
+++ b/scripts/steps/08_visualize_asic_synthesis_results_1.source_bash
@@ -1,3 +1,3 @@
 . "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/00_setup.source_bash"
 
-run_openlane_layout_viewer openroad
+run_librelane_layout_viewer openroad

--- a/scripts/steps/09_visualize_asic_synthesis_results_2.source_bash
+++ b/scripts/steps/09_visualize_asic_synthesis_results_2.source_bash
@@ -1,3 +1,3 @@
 . "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/00_setup.source_bash"
 
-run_openlane_layout_viewer klayout
+run_librelane_layout_viewer klayout


### PR DESCRIPTION
Migrates existing OpenLane Flow to LibreLane. The recommended method for installing Librelane and all its runtime dependencies (verilator, openroad, etc.) is via Nix, although it supports at minimum a custom librelane binary path.

Useful reference for migrating/comparing OpenLane flow: https://librelane.readthedocs.io/en/stable/getting_started/migrants/index.html

As of now, the RTL-GDS flow works. The below are some features that are still being worked or could be worked on

- [x] Support visualize_asic_synthesis_results by implementing run_openlane_layout_viewer
~~- [ ] Pin sky130 PDK version with Nix flake~~ Not needed, and Nix doesn't seem to have packages for this
- [x] Explicitly define PDK to use (default for Librelane is already sky130A, but this can be useful to doing other PDKs)