### PR TITLE
Add: Modified double buffer

### DIFF
--- a/labs/4_microarchitecture/4_3_pipelines_2/4_3_1_pow_5_single_cycle/fcr_6_double_buffer_from_dally_harting_modified.sv
+++ b/labs/4_microarchitecture/4_3_pipelines_2/4_3_1_pow_5_single_cycle/fcr_6_double_buffer_from_dally_harting_modified.sv
@@ -1,0 +1,66 @@
+// Asynchronous reset here is needed for one of FPGA boards we use
+
+`include "config.svh"
+
+// This solution is a Yuri Panchul's edition
+// of the code derived from:
+//
+// Digital Design: A Systems Approach
+// by William James Dally and R. Curtis Harting
+// 2012
+// 
+// Modified by Arseniy Lyskov
+
+// It is equivalent to 2-deep FIFO
+
+module fcr_6_double_buffer_from_dally_harting_modified
+# (
+    parameter w = 0
+)
+(
+    input                  clk,
+    input                  rst,
+
+    input                  up_vld,
+    output logic           up_rdy,
+    input        [w - 1:0] up_data,
+
+    output logic           down_vld,
+    input                  down_rdy,
+    output logic [w - 1:0] down_data
+);
+
+    logic           enable;
+    logic           buf_vld;
+    logic [w - 1:0] buf_data;
+    
+    assign enable = down_rdy | ~down_vld;
+
+    always_ff @ (posedge clk)
+    begin
+        if (up_rdy & ~ down_rdy)
+            buf_data <= up_data;
+
+        if (enable)
+            down_data <= up_rdy ? up_data : buf_data;
+    end
+
+    always_ff @ (posedge clk or posedge rst)
+        if (rst)
+        begin
+            buf_vld  <= 1'b0;
+            down_vld <= 1'b0;
+            up_rdy   <= 1'b1;
+        end
+        else
+        begin
+            if (up_rdy & ~ down_rdy)
+                buf_vld  <= up_vld;
+
+            if (enable)
+                down_vld <= up_rdy ? up_vld : buf_vld;
+
+            up_rdy <= enable;
+        end
+
+endmodule

--- a/labs/4_microarchitecture/4_3_pipelines_2/4_3_1_pow_5_single_cycle/pow_5_single_cycle.sv
+++ b/labs/4_microarchitecture/4_3_pipelines_2/4_3_1_pow_5_single_cycle/pow_5_single_cycle.sv
@@ -7,6 +7,7 @@
 // `define FCR fcr_3_single_for_pipes_with_global_stall
 // `define FCR fcr_4_wrapped_2_deep_fifo
 // `define FCR fcr_5_double_buffer_from_dally_harting
+// `define FCR fcr_6_double_buffer_from_dally_harting_modified
 
 module pow_5_single_cycle
 # (

--- a/labs/4_microarchitecture/4_3_pipelines_2/4_3_2_pow_5_pipelined/fcr_6_double_buffer_from_dally_harting_modified.sv
+++ b/labs/4_microarchitecture/4_3_pipelines_2/4_3_2_pow_5_pipelined/fcr_6_double_buffer_from_dally_harting_modified.sv
@@ -1,0 +1,66 @@
+// Asynchronous reset here is needed for one of FPGA boards we use
+
+`include "config.svh"
+
+// This solution is a Yuri Panchul's edition
+// of the code derived from:
+//
+// Digital Design: A Systems Approach
+// by William James Dally and R. Curtis Harting
+// 2012
+// 
+// Modified by Arseniy Lyskov
+
+// It is equivalent to 2-deep FIFO
+
+module fcr_6_double_buffer_from_dally_harting_modified
+# (
+    parameter w = 0
+)
+(
+    input                  clk,
+    input                  rst,
+
+    input                  up_vld,
+    output logic           up_rdy,
+    input        [w - 1:0] up_data,
+
+    output logic           down_vld,
+    input                  down_rdy,
+    output logic [w - 1:0] down_data
+);
+
+    logic           enable;
+    logic           buf_vld;
+    logic [w - 1:0] buf_data;
+    
+    assign enable = down_rdy | ~down_vld;
+
+    always_ff @ (posedge clk)
+    begin
+        if (up_rdy & ~ down_rdy)
+            buf_data <= up_data;
+
+        if (enable)
+            down_data <= up_rdy ? up_data : buf_data;
+    end
+
+    always_ff @ (posedge clk or posedge rst)
+        if (rst)
+        begin
+            buf_vld  <= 1'b0;
+            down_vld <= 1'b0;
+            up_rdy   <= 1'b1;
+        end
+        else
+        begin
+            if (up_rdy & ~ down_rdy)
+                buf_vld  <= up_vld;
+
+            if (enable)
+                down_vld <= up_rdy ? up_vld : buf_vld;
+
+            up_rdy <= enable;
+        end
+
+endmodule

--- a/labs/4_microarchitecture/4_3_pipelines_2/4_3_2_pow_5_pipelined/pow_5_pipelined.sv
+++ b/labs/4_microarchitecture/4_3_pipelines_2/4_3_2_pow_5_pipelined/pow_5_pipelined.sv
@@ -7,6 +7,7 @@
 // `define FCR fcr_3_single_for_pipes_with_global_stall
 // `define FCR fcr_4_wrapped_2_deep_fifo
 // `define FCR fcr_5_double_buffer_from_dally_harting
+// `define FCR fcr_6_double_buffer_from_dally_harting_modified
 
 module pow_5_pipelined
 # (


### PR DESCRIPTION
Продолжение yuri-panchul/systemverilog-homework#30

Заметить повышение пропускной способности буфера можно по логам тестбенчей

#### Пример с возведением в степень за один такт:
    fcr_5: number of transfers : up 41 down 41 per 105 cycles
    fcr_6: number of transfers : up 48 down 48 per 103 cycles
    
Временные диаграммы:
<img width="70%" alt="double_buffer" src="https://github.com/user-attachments/assets/ef10661d-5b98-4a2c-b978-bb2f69f7d5d3"/> 
<img width="70%" alt="double_buffer_modified" src="https://github.com/user-attachments/assets/e765b0e4-4a95-4572-9843-547ae239f871"/>

#### Пример с конвейером:
    fcr_5: number of transfers : up 46 down 46 per 107 cycles
    fcr_6: number of transfers : up 52 down 52 per 108 cycles

#### Кроме того, для изначальной версии:
Если приёмник выставляет `down_ready` только при `down_valid` (как в https://code2silicon.ru/problems/05_05), а данные в буфере невалидны, возникает "дедлок". В данном случае приёмник должен, учитывая внутреннее устройство буфера, также выставлять `down_ready` при `~down_valid`, пропуская невалидные данные. А в задаче на платформе буфер дан как чёрный ящик, так что основываясь лишь на valid/ready портах модуля такая логика может показаться внезапной